### PR TITLE
APPS-336 Fix bug caused by requireauthentication=true

### DIFF
--- a/src/main/java/com/aerospike/restclient/config/AerospikeClientConfig.java
+++ b/src/main/java/com/aerospike/restclient/config/AerospikeClientConfig.java
@@ -23,6 +23,7 @@ import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.restclient.util.AerospikeClientPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -76,8 +77,10 @@ public class AerospikeClientConfig {
     int poolSize;
 
     @Bean
-    public AerospikeClientPool configAerospikeClientPool(ClientPolicy policy, AerospikeClient defaultClient) {
-        return new AerospikeClientPool(poolSize, policy, port, hostList, hostname, defaultClient, useBoolBin);
+    public AerospikeClientPool configAerospikeClientPool(ClientPolicy policy,
+                                                         ObjectProvider<AerospikeClient> defaultClient) {
+        return new AerospikeClientPool(poolSize, policy, port, hostList, hostname, defaultClient.getIfAvailable(),
+                useBoolBin);
     }
 }
 

--- a/src/test/java/com/aerospike/restclient/ConfigRequireAuthTest.java
+++ b/src/test/java/com/aerospike/restclient/ConfigRequireAuthTest.java
@@ -1,0 +1,15 @@
+package com.aerospike.restclient;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(properties = "aerospike.restclient.requireAuthentication=true")
+public class ConfigRequireAuthTest {
+    @Test
+    public void startUpTest() {
+        // Tests that the application will startup even without an default AerospikeClient instantiated.
+    }
+}


### PR DESCRIPTION
ACMS came across this issue in one of its tests.  

The bug was introduced in 2.0 when we remove 
```
    @Autowired
    @Nullable
    AerospikeClient defaultClient;
```

Starting with Springframework 5 you are not allowed to directly inject a null bean.  Somehow the above @Autowired annotation gets around that.  [Here](https://stackoverflow.com/questions/49044770/change-in-how-spring-5-handles-null-beans) is an answer from a Springframework maintainer who recommends the use of `ObjectProvider`