### PR TITLE
fix: Use eclipse-temurin instead of deprecated openjdk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Set up Aerospike Database
         uses: reugn/github-action-aerospike@v1
+        with:
+          server-version: 6.1.0.3
 
       - name: Cache Gradle packages
         uses: actions/cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM openjdk:19-jdk-alpine AS build
+FROM eclipse-temurin:17-jdk AS build
 WORKDIR /workspace/app
 
 COPY . /workspace/app
 RUN ./gradlew clean build -x test
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*[^plain].jar)
 
-FROM openjdk:19-jdk-alpine
+FROM eclipse-temurin:17-jre
 VOLUME /tmp
 ARG DEPENDENCY=/workspace/app/build/dependency
 COPY --from=build ${DEPENDENCY}/BOOT-INF/lib /app/lib


### PR DESCRIPTION
This was already done but accidentally overwritten by another PR.