### PR TITLE
APPS-364 support multi-architecture docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 .git
 .cache
 .github
+.gradle
 build
+target
 
 .idea
 .vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM eclipse-temurin:17-jdk AS build
 WORKDIR /workspace/app
 
+# Needed for arm64 support. Open gradle issue: https://github.com/gradle/gradle/issues/18212
+ENV JAVA_OPTS="-Djdk.lang.Process.launchMechanism=vfork"
+
 COPY . /workspace/app
 RUN ./gradlew clean build -x test
 RUN mkdir -p build/dependency && (cd build/dependency; jar -xf ../libs/*[^plain].jar)


### PR DESCRIPTION
The one change needed took quite a bit of time to figure out.  I did find an open issue that covers the topic nicely. https://github.com/gradle/gradle/issues/18212

Oddly enough, another fix I found was to change the max heap size of the JVM inside ./gradlew and run gradle with `--no-daemon`. 