### PR TITLE
The recordBins parameter can be parsed as parameter having indexes in a query

### DIFF
--- a/src/main/java/com/aerospike/restclient/util/RequestParamHandler.java
+++ b/src/main/java/com/aerospike/restclient/util/RequestParamHandler.java
@@ -24,8 +24,7 @@ import com.aerospike.restclient.util.converters.StatementConverter;
 import com.aerospike.restclient.util.converters.policyconverters.*;
 import org.springframework.util.MultiValueMap;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public final class RequestParamHandler {
 
@@ -33,11 +32,24 @@ public final class RequestParamHandler {
     }
 
     public static String[] getBinsFromMap(MultiValueMap<String, String> requestParams) {
-        List<String> binStr = requestParams.get(AerospikeAPIConstants.RECORD_BINS);
-        if (binStr == null) {
-            return new String[0];
+        if (requestParams.containsKey(AerospikeAPIConstants.RECORD_BINS)) {
+            List<String> binStr = requestParams.get(AerospikeAPIConstants.RECORD_BINS);
+            if (binStr == null) {
+                return new String[0];
+            }
+            return binStr.toArray(new String[0]);
         }
-        return binStr.toArray(new String[0]);
+
+        List<String> values = new ArrayList<>();
+        for (String key : requestParams.keySet()) {
+            if (key.startsWith(AerospikeAPIConstants.RECORD_BINS)) {
+                values.add(requestParams.get(key).get(0));
+            }
+        }
+
+        String[] returnValues = new String[values.size()];
+
+        return values.toArray(returnValues);
     }
 
     public static String[] getKeysFromMap(MultiValueMap<String, String> requestParams) {

--- a/src/main/java/com/aerospike/restclient/util/converters/StatementConverter.java
+++ b/src/main/java/com/aerospike/restclient/util/converters/StatementConverter.java
@@ -29,7 +29,10 @@ public class StatementConverter {
     public static Statement statementFromMultiMap(MultiValueMap<String, String> stmtMultiMap) {
         Statement stmt = new Statement();
 
-        if (stmtMultiMap.containsKey(AerospikeAPIConstants.RECORD_BINS)) {
+        boolean hasRecordBinParameters =
+                stmtMultiMap.keySet().stream().anyMatch(key -> key.startsWith(AerospikeAPIConstants.RECORD_BINS));
+
+        if (hasRecordBinParameters) {
             stmt.setBinNames(RequestParamHandler.getBinsFromMap(stmtMultiMap));
         }
 

--- a/src/test/java/com/aerospike/restclient/converters/RequestParamHandlerTests.java
+++ b/src/test/java/com/aerospike/restclient/converters/RequestParamHandlerTests.java
@@ -42,6 +42,18 @@ public class RequestParamHandlerTests {
     }
 
     @Test
+    public void getIndexedBinsFromMultiMapTest() {
+        String[] expectedBins = {"bin1", "bin2", "bin3"};
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.put(AerospikeAPIConstants.RECORD_BINS + "[0]", Arrays.asList(expectedBins).subList(0,1));
+        params.put(AerospikeAPIConstants.RECORD_BINS + "[1]", Arrays.asList(expectedBins).subList(1,2));
+        params.put(AerospikeAPIConstants.RECORD_BINS + "[2]", Arrays.asList(expectedBins).subList(2,3));
+
+        String[] actualBins = RequestParamHandler.getBinsFromMap(params);
+        Assert.assertArrayEquals(expectedBins, actualBins);
+    }
+
+    @Test
     public void getKeyTypeFromMultiMapTest() {
         RecordKeyType expectedType = RecordKeyType.DIGEST;
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();


### PR DESCRIPTION
Currently only lists are allowed in the following format:

/query/mynamespace/myset?recordBins=bin1&recordBins=bin2

Unfortunately there are multiple possible ways to transmit that information and e.g. code generators might handle it differently.

To make the REST gateway a little bit more independent, this MR suggests to open it up to the following possible paramater format:
/query/mynamespace/myset?recordBins[]=bin1&recordBins[]=bin2
/query/mynamespace/myset?recordBins[0]=bin1&recordBins[1]=bin2

I tried to find the least invasive spot. If there's a proper parsing and preparation of the request parameters earlier in the process, I'm happy to have a look there.