### PR TITLE
fix: APPS-657 support batch reads on older servers

### DIFF
--- a/src/main/java/com/aerospike/restclient/controllers/BatchController.java
+++ b/src/main/java/com/aerospike/restclient/controllers/BatchController.java
@@ -50,7 +50,8 @@ public class BatchController {
     private AerospikeBatchService service;
 
     @Operation(
-            summary = "Return multiple records from the server in a single request.", operationId = "performBatchGet"
+            summary = "Return multiple records from the server in a single request. Write, Delete, and UDFs are only allowed on aerospike servers 6.0+",
+            operationId = "performBatch"
     )
     @ApiResponses(
             value = {
@@ -60,7 +61,7 @@ public class BatchController {
                             content = @Content(array = @ArraySchema(schema = @Schema(implementation = BatchRecordResponse.class)))
                     ), @ApiResponse(
                     responseCode = "400",
-                    description = "Invalid parameters or request.",
+                    description = "Invalid parameters or request. Write, Delete, and UDFs are only allowed on aerospike servers 6.0+",
                     content = @Content(schema = @Schema(implementation = RestClientError.class))
             ), @ApiResponse(
                     responseCode = "403",

--- a/src/main/java/com/aerospike/restclient/handlers/BatchHandler.java
+++ b/src/main/java/com/aerospike/restclient/handlers/BatchHandler.java
@@ -17,6 +17,7 @@
 package com.aerospike.restclient.handlers;
 
 import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.BatchRead;
 import com.aerospike.client.BatchRecord;
 import com.aerospike.client.policy.BatchPolicy;
 
@@ -31,7 +32,14 @@ public class BatchHandler {
     }
 
     public void batchRecord(BatchPolicy policy, List<BatchRecord> batchRecords) {
-        client.operate(policy, batchRecords);
+        boolean allBatchRead = batchRecords.stream().allMatch(r -> r instanceof BatchRead);
+
+        if (allBatchRead) {
+            // Supported on old servers
+            client.get(policy, batchRecords.stream().map(r -> (BatchRead) r).toList());
+        } else {
+            client.operate(policy, batchRecords);
+        }
     }
 
     public static BatchHandler create(AerospikeClient client) {

--- a/src/test/java/com/aerospike/restclient/BatchCorrectTests.java
+++ b/src/test/java/com/aerospike/restclient/BatchCorrectTests.java
@@ -158,7 +158,7 @@ public class BatchCorrectTests {
         List<Map<String, Object>> returnedRecords = (List<Map<String, Object>>) batchResponse.get("batchRecords");
         Assert.assertEquals(3, returnedRecords.size());
 
-        client.operate(null, batchRecs);
+        client.get(null, batchRecs.stream().map(r -> (BatchRead) r).toList());
         Assert.assertTrue(compareRestRecordsToBatchRecords(returnedRecords, batchRecs));
     }
 
@@ -204,7 +204,7 @@ public class BatchCorrectTests {
         List<Map<String, Object>> returnedRecords = (List<Map<String, Object>>) batchResponse.get("batchRecords");
         Assert.assertEquals(3, returnedRecords.size());
 
-        client.operate(null, batchRecs);
+        client.get(null, batchRecs.stream().map(r -> (BatchRead) r).toList());
         Assert.assertTrue(compareRestRecordsToBatchRecords(returnedRecords, batchRecs));
     }
 
@@ -227,7 +227,7 @@ public class BatchCorrectTests {
         List<Map<String, Object>> returnedRecords = (List<Map<String, Object>>) batchResponse.get("batchRecords");
         Assert.assertEquals(4, returnedRecords.size());
 
-        client.operate(null, batchRecs);
+        client.get(null, batchRecs.stream().map(r -> (BatchRead) r).toList());
         Assert.assertTrue(compareRestRecordsToBatchRecords(returnedRecords, batchRecs));
     }
 
@@ -250,7 +250,7 @@ public class BatchCorrectTests {
         List<Map<String, Object>> returnedRecords = (List<Map<String, Object>>) batchResponse.get("batchRecords");
         Assert.assertEquals(4, returnedRecords.size());
 
-        client.operate(null, batchRecs);
+        client.get(null, batchRecs.stream().map(r -> (BatchRead) r).toList());
         Assert.assertTrue(compareRestRecordsToBatchRecords(returnedRecords, batchRecs));
     }
 
@@ -266,7 +266,7 @@ public class BatchCorrectTests {
         List<Map<String, Object>> returnedRecords = (List<Map<String, Object>>) batchResponse.get("batchRecords");
         Assert.assertEquals(1, returnedRecords.size());
 
-        client.operate(null, batchRecs);
+        client.get(null, batchRecs.stream().map(r -> (BatchRead) r).toList());
         Assert.assertTrue(compareRestRecordsToBatchRecords(returnedRecords, batchRecs));
     }
 
@@ -282,7 +282,7 @@ public class BatchCorrectTests {
         List<Map<String, Object>> returnedRecords = (List<Map<String, Object>>) batchResponse.get("batchRecords");
         Assert.assertEquals(1, returnedRecords.size());
 
-        client.operate(null, batchRecs);
+        client.get(null, batchRecs.stream().map(r -> (BatchRead) r).toList());
         Assert.assertTrue(compareRestRecordsToBatchRecords(returnedRecords, batchRecs));
     }
 


### PR DESCRIPTION
Batch Write, Delete, and UDF are only supported on servers 6.0. The aerospike client operate API on the aerospike client is only supported on servers 6.0+. In order to perform a Batch Read we must use the aerospike clients older get API.
Fixes #118 