### PR TITLE
APPS-730 fix yaml vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,9 @@ version = gitVersion
 
 bootJar {
     baseName "${jarBaseName}"
-    version "${gitVersion}"
+}
+jar {
+    baseName "${jarBaseName}"
 }
 test {
     testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
         springBootVersion = "2.7.11"
         httpclientVersion = "4.5.14"
         aerospikeClientVersion = findProperty("aerospikeClientVersion") ?: "6.1.9"
+        set('snakeyaml.version', '1.32') // Can be removed after upgrading to springboot 3.x
     }
     if (findProperty("aerospikeUseLocal")) {
         print("using Local repo")
@@ -33,7 +34,6 @@ repositories {
     mavenCentral()
 }
 
-
 apply plugin: "java"
 apply plugin: "eclipse"
 apply plugin: "org.springframework.boot"
@@ -43,7 +43,10 @@ group = "com.aerospike"
 sourceCompatibility = 17
 
 def gitVersionDetails = versionDetails()
-def gitVersion = gitVersionDetails.lastTag + "-" + gitVersionDetails.commitDistance + "-" + gitVersionDetails.gitHash
+def gitVersion = gitVersionDetails.lastTag
+if (gitVersionDetails.commitDistance != 0) {
+    gitVersion = gitVersion + "-" + gitVersionDetails.commitDistance + "-" + gitVersionDetails.gitHash
+}
 version = gitVersion
 
 bootJar {

--- a/docs/installation-and-config.md
+++ b/docs/installation-and-config.md
@@ -55,7 +55,7 @@ docker build -t aerospike-rest-gateway .
 * Run the REST Gateway using docker
 
 ```sh
-docker run -itd --rm -p 8080:8080 --name AS_Rest1 -e aerospike_restclient_hostname=172.17.0.3 aerospike-rest-gateway
+docker run -itd --rm -p 8080:8080 --name as-rest -e aerospike_restclient_hostname=172.17.0.3 aerospike-rest-gateway
 ```
 
 ### Run on Kubernetes

--- a/docs/package-directions.md
+++ b/docs/package-directions.md
@@ -13,11 +13,13 @@ client.
 
 ## First steps
 
-**Note** The following directions assume that the Rest Gateway is listening on `http://localhost:8080/aerospike-rest-gateway`,
+**Note** The following directions assume that the Rest Gateway is listening
+on `http://localhost:8080/`,
 if this is not the case, change the URLS accordingly.
 
 To get a quick introduction to the API and usage of the Rest Gateway we recommend visiting the Interactive Documentation
-which will be located at <http://localhost:8080/aerospike-rest-gateway/swagger-ui.html> . This Interface shows all of the API
+which will be located at <http://localhost:8080/swagger-ui/index.html> . This Interface shows all the
+API
 endpoints, and allows you to try them out from a browser.
 
 ## Further information


### PR DESCRIPTION
PR mainly to fix this vulnerability https://nvd.nist.gov/vuln/detail/CVE-2022-1471. However, it does not affect us because we do not accept yaml in our request body. I also fixed an issue with the *plain.jar using the old rest-client name instead of the new rest-gateway name.  Lastly, I fixed the version code not to include the distance and hash if the distance from the tag is zero, meaning the current commit is tagged. This falls more in line with the behavior of `git describe`.

We will release 2.1.1 after this is merged