### PR TITLE
fix: Raises error when reading java-serialized blobs instead of retuning byte array

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -3,10 +3,11 @@ name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 
 on:
   # Runs on pushes targeting the default branch
-  push:
-    tags: [ "*" ]
+  #  push:
+  #    tags: [ "*" ]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # Currently the only way to successfully run this workflow. push: tags does not work. Hopefully it will in the future.
+  # Allows you to run this workflow manually from the Actions tab.
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -4,7 +4,7 @@ name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 on:
   # Runs on pushes targeting the default branch
   push:
-    tags: ["*"]
+    tags: [ "*" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -28,8 +28,8 @@ jobs:
     needs: generate-openapi-spec
     runs-on: ubuntu-latest
     steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
+      #      - name: Checkout
+      #        uses: actions/checkout@v3
       - name: Download Package
         uses: actions/download-artifact@v3
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         springBootVersion = "2.7.11"
         httpclientVersion = "4.5.14"
-        aerospikeClientVersion = findProperty("aerospikeClientVersion") ?: "7.0.0"
+        aerospikeClientVersion = findProperty("aerospikeClientVersion") ?: "7.1.0"
         set('snakeyaml.version', '2.0') // Can be removed after upgrading to springboot 3.x
     }
     if (findProperty("aerospikeUseLocal")) {


### PR DESCRIPTION
This upgrades java client 7.0.0 to 7.1.0. Java client 7.1.0 returns language-specific serialized objects as byte arrays instead of raising an error like in java client 7.0.0.