### PR TITLE
Apps 886 apps 887 fix swagger models

### DIFF
--- a/src/main/java/com/aerospike/restclient/domain/RestClientError.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientError.java
@@ -29,7 +29,7 @@ public class RestClientError {
 
     @Schema(
             description = "A boolean specifying whether it was possible that the operation succeeded. This is only included if true.",
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             example = "false"
     )
     private final Boolean inDoubt;

--- a/src/main/java/com/aerospike/restclient/domain/RestClientKey.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientKey.java
@@ -31,7 +31,7 @@ import java.util.Base64.Encoder;
 
 public class RestClientKey {
 
-    @Schema(required = true, example = "testNS")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, example = "testNS")
     public String namespace;
 
     @JsonProperty(value = "setName")
@@ -46,7 +46,7 @@ public class RestClientKey {
     public RecordKeyType keyType;
 
     @Schema(
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             description = "The user key, it may be a string, integer, or URL safe Base64 encoded bytes.",
             example = "userKey"
     )

--- a/src/main/java/com/aerospike/restclient/domain/RestClientKeyRecord.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientKeyRecord.java
@@ -37,9 +37,11 @@ public class RestClientKeyRecord {
         bins = rec.bins;
     }
 
-    @Schema(required = true,
+    @Schema(
+            requiredMode = Schema.RequiredMode.REQUIRED,
             description = "The user key, it may be a string, integer, or URL safe Base64 encoded bytes.",
-            example = "userKey")
+            example = "userKey"
+    )
     public Object userKey;
 
     @Schema(name = "generation", description = "The generation of the record.", example = "2")
@@ -48,7 +50,10 @@ public class RestClientKeyRecord {
     @Schema(name = "ttl", description = "The time to live for the record, in seconds from now.", example = "1000")
     public int ttl;
 
-    @Schema(name = "bins", description = "A mapping from binName to binValue",
-            example = "{\"bin1\": \"val1\", \"pi\": \"3.14\"}")
+    @Schema(
+            name = "bins",
+            description = "A mapping from binName to binValue",
+            example = "{\"bin1\": \"val1\", \"pi\": \"3.14\"}"
+    )
     public Map<String, Object> bins;
 }

--- a/src/main/java/com/aerospike/restclient/domain/RestClientOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientOperation.java
@@ -55,11 +55,13 @@ public class RestClientOperation {
     }
 
     @Schema(
-            required = true, description = "Aerospike operation to perform on the record", example = "LIST_APPEND_ITEMS"
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            description = "Aerospike operation to perform on the record",
+            example = "LIST_APPEND_ITEMS"
     )
     private AerospikeOperation operation;
 
-    @Schema(required = true, example = "{\"bin\":\"listbin\", \"values\":[1,2,3]}")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, example = "{\"bin\":\"listbin\", \"values\":[1,2,3]}")
     private Map<String, Object> opValues;
 
     public AerospikeOperation getOperation() {

--- a/src/main/java/com/aerospike/restclient/domain/RestClientPrivilege.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientPrivilege.java
@@ -25,7 +25,7 @@ import javax.validation.constraints.NotNull;
 public class RestClientPrivilege {
 
     @NotNull
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     PrivilegeCode code;
 
     @Schema(description = "Namespace Scope", example = "testNS")

--- a/src/main/java/com/aerospike/restclient/domain/RestClientRole.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientRole.java
@@ -28,11 +28,11 @@ import java.util.List;
 public class RestClientRole {
 
     @NotNull
-    @Schema(required = true, description = "Role name.", example = "customRole")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "Role name.", example = "customRole")
     private String name;
 
     @NotNull
-    @Schema(required = true, description = "List of assigned privileges.")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED, description = "List of assigned privileges.")
     private List<RestClientPrivilege> privileges;
 
     @Schema(description = "List of allowable IP addresses.")

--- a/src/main/java/com/aerospike/restclient/domain/batchmodels/BatchDelete.java
+++ b/src/main/java/com/aerospike/restclient/domain/batchmodels/BatchDelete.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 public class BatchDelete extends BatchRecord {
     @Schema(
             description = "The type of batch request. It is always " + AerospikeAPIConstants.BATCH_TYPE_DELETE,
-            allowableValues = AerospikeAPIConstants.BATCH_TYPE_DELETE,
+            allowableValues = {AerospikeAPIConstants.BATCH_TYPE_DELETE},
             required = true
     )
     public final String type = AerospikeAPIConstants.BATCH_TYPE_DELETE;

--- a/src/main/java/com/aerospike/restclient/domain/batchmodels/BatchRead.java
+++ b/src/main/java/com/aerospike/restclient/domain/batchmodels/BatchRead.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class BatchRead extends BatchRecord {
     @Schema(
             description = "The type of batch request. It is always " + AerospikeAPIConstants.BATCH_TYPE_READ,
-            allowableValues = AerospikeAPIConstants.BATCH_TYPE_READ,
+            allowableValues = {AerospikeAPIConstants.BATCH_TYPE_READ},
             required = true
     )
     public final String type = AerospikeAPIConstants.BATCH_TYPE_READ;

--- a/src/main/java/com/aerospike/restclient/domain/batchmodels/BatchUDF.java
+++ b/src/main/java/com/aerospike/restclient/domain/batchmodels/BatchUDF.java
@@ -38,7 +38,7 @@ public class BatchUDF extends BatchRecord {
 
     @Schema(
             description = "List of bins to limit the record response to.",
-            allowableValues = AerospikeAPIConstants.BATCH_TYPE_UDF,
+            allowableValues = {AerospikeAPIConstants.BATCH_TYPE_UDF},
             required = true
     )
     @JsonProperty(required = true)

--- a/src/main/java/com/aerospike/restclient/domain/batchmodels/BatchWrite.java
+++ b/src/main/java/com/aerospike/restclient/domain/batchmodels/BatchWrite.java
@@ -36,7 +36,7 @@ public class BatchWrite extends BatchRecord {
 
     @Schema(
             description = "List of bins to limit the record response to.",
-            allowableValues = AerospikeAPIConstants.BATCH_TYPE_WRITE,
+            allowableValues = {AerospikeAPIConstants.BATCH_TYPE_WRITE},
             required = true
     )
     @JsonProperty(required = true)

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/ListIndexCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/ListIndexCTX.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class ListIndexCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.LIST_INDEX,
-            allowableValues = AerospikeAPIConstants.CTX.LIST_INDEX,
+            allowableValues = {AerospikeAPIConstants.CTX.LIST_INDEX},
             required = true
     )
     public final String type = AerospikeAPIConstants.CTX.LIST_INDEX;

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/ListIndexCreateCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/ListIndexCreateCTX.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class ListIndexCreateCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.LIST_INDEX_CREATE,
-            allowableValues = AerospikeAPIConstants.CTX.LIST_INDEX_CREATE,
+            allowableValues = {AerospikeAPIConstants.CTX.LIST_INDEX_CREATE},
             required = true
     )
     public final String type = AerospikeAPIConstants.CTX.LIST_INDEX_CREATE;

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/ListRankCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/ListRankCTX.java
@@ -27,7 +27,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class ListRankCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.LIST_RANK,
-            allowableValues = AerospikeAPIConstants.CTX.LIST_RANK,
+            allowableValues = {AerospikeAPIConstants.CTX.LIST_RANK},
             required = true
     )
     public final String type = AerospikeAPIConstants.CTX.LIST_RANK;

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/ListValueCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/ListValueCTX.java
@@ -31,7 +31,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class ListValueCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.LIST_VALUE,
-            allowableValues = AerospikeAPIConstants.CTX.LIST_VALUE,
+            allowableValues = {AerospikeAPIConstants.CTX.LIST_VALUE},
             required = true
     )
     @JsonProperty(required = true)

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapIndexCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapIndexCTX.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class MapIndexCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.MAP_INDEX,
-            allowableValues = AerospikeAPIConstants.CTX.MAP_INDEX,
+            allowableValues = {AerospikeAPIConstants.CTX.MAP_INDEX},
             required = true
     )
     @JsonProperty(required = true)

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapKeyCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapKeyCTX.java
@@ -31,7 +31,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class MapKeyCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.MAP_KEY,
-            allowableValues = AerospikeAPIConstants.CTX.MAP_KEY,
+            allowableValues = {AerospikeAPIConstants.CTX.MAP_KEY},
             required = true
     )
     @JsonProperty(required = true)

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapKeyCreateCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapKeyCreateCTX.java
@@ -32,7 +32,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class MapKeyCreateCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.MAP_KEY_CREATE,
-            allowableValues = AerospikeAPIConstants.CTX.MAP_KEY_CREATE,
+            allowableValues = {AerospikeAPIConstants.CTX.MAP_KEY_CREATE},
             required = true
     )
     @JsonProperty(required = true)

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapRankCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapRankCTX.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class MapRankCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.MAP_RANK,
-            allowableValues = AerospikeAPIConstants.CTX.MAP_RANK,
+            allowableValues = {AerospikeAPIConstants.CTX.MAP_RANK},
             required = true
     )
     public final String type = AerospikeAPIConstants.CTX.MAP_RANK;

--- a/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapValueCTX.java
+++ b/src/main/java/com/aerospike/restclient/domain/ctxmodels/MapValueCTX.java
@@ -31,7 +31,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class MapValueCTX extends CTX {
     @Schema(
             description = "The type of context this object represents. It is always " + AerospikeAPIConstants.CTX.MAP_VALUE,
-            allowableValues = AerospikeAPIConstants.CTX.MAP_VALUE,
+            allowableValues = {AerospikeAPIConstants.CTX.MAP_VALUE},
             required = true
     )
     @JsonProperty(required = true)

--- a/src/main/java/com/aerospike/restclient/domain/geojsonmodels/AeroCircle.java
+++ b/src/main/java/com/aerospike/restclient/domain/geojsonmodels/AeroCircle.java
@@ -32,7 +32,7 @@ public class AeroCircle extends GeoJSON {
             allowableValues = {AerospikeAPIConstants.GeoJSON.Types.AERO_CIRCLE},
             required = true
     )
-    public final String type = AerospikeAPIConstants.GeoJSON.Types.AERO_CIRCLE;
+    public String type = AerospikeAPIConstants.GeoJSON.Types.AERO_CIRCLE;
 
     public LngLatRad coordinates;
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/AddOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/AddOperation.java
@@ -33,9 +33,9 @@ public class AddOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.ADD,
             required = true,
-            allowableValues = OperationTypes.ADD
+            allowableValues = {OperationTypes.ADD}
     )
-    final public static String type = OperationTypes.ADD;
+    final public String type = OperationTypes.ADD;
 
     @Schema(required = true)
     private final String binName;
@@ -44,8 +44,11 @@ public class AddOperation extends Operation {
     private final Number incr;
 
     @JsonCreator
-    public AddOperation(@JsonProperty(value = "binName", required = true) String binName,
-                        @JsonProperty(value = "incr", required = true) Number incr) {
+    public AddOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "incr") @Schema(
+            name = "incr", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Number incr) {
         this.binName = binName;
         this.incr = incr;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/AppendOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/AppendOperation.java
@@ -32,9 +32,9 @@ public class AppendOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.APPEND,
             required = true,
-            allowableValues = OperationTypes.APPEND
+            allowableValues = {OperationTypes.APPEND}
     )
-    final public static String type = OperationTypes.APPEND;
+    final public String type = OperationTypes.APPEND;
 
     @Schema(required = true)
     private final String binName;
@@ -43,8 +43,11 @@ public class AppendOperation extends Operation {
     private final String value;
 
     @JsonCreator
-    public AppendOperation(@JsonProperty(value = "binName", required = true) String binName,
-                           @JsonProperty(value = "value", required = true) String value) {
+    public AppendOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String value) {
         this.binName = binName;
         this.value = value;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitAddOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitAddOperation.java
@@ -32,9 +32,9 @@ public class BitAddOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_ADD,
             required = true,
-            allowableValues = OperationTypes.BIT_ADD
+            allowableValues = {OperationTypes.BIT_ADD}
     )
-    final public static String type = OperationTypes.BIT_ADD;
+    final public String type = OperationTypes.BIT_ADD;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -50,10 +50,15 @@ public class BitAddOperation extends BitOperation {
     private BitOverflowAction action = BitOverflowAction.FAIL;
 
     @JsonCreator
-    public BitAddOperation(@JsonProperty(value = "binName", required = true) String binName,
-                           @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                           @JsonProperty(value = "bitSize", required = true) int bitSize,
-                           @JsonProperty(value = "value", required = true) long value) {
+    public BitAddOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) long value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitAndOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitAndOperation.java
@@ -31,9 +31,9 @@ public class BitAndOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_AND,
             required = true,
-            allowableValues = OperationTypes.BIT_AND
+            allowableValues = {OperationTypes.BIT_AND}
     )
-    final public static String type = OperationTypes.BIT_AND;
+    final public String type = OperationTypes.BIT_AND;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -45,10 +45,15 @@ public class BitAndOperation extends BitOperation {
     private final byte[] value;
 
     @JsonCreator
-    public BitAndOperation(@JsonProperty(value = "binName", required = true) String binName,
-                           @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                           @JsonProperty(value = "bitSize", required = true) int bitSize,
-                           @JsonProperty(value = "value", required = true) byte[] value) {
+    public BitAndOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) byte[] value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitCountOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitCountOperation.java
@@ -30,9 +30,9 @@ public class BitCountOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_COUNT,
             required = true,
-            allowableValues = OperationTypes.BIT_COUNT
+            allowableValues = {OperationTypes.BIT_COUNT}
     )
-    final public static String type = OperationTypes.BIT_COUNT;
+    final public String type = OperationTypes.BIT_COUNT;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -41,9 +41,13 @@ public class BitCountOperation extends BitOperation {
     private final int bitSize;
 
     @JsonCreator
-    public BitCountOperation(@JsonProperty(value = "binName", required = true) String binName,
-                             @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                             @JsonProperty(value = "bitSize", required = true) int bitSize) {
+    public BitCountOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitGetIntOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitGetIntOperation.java
@@ -30,9 +30,9 @@ public class BitGetIntOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_GET_INT,
             required = true,
-            allowableValues = OperationTypes.BIT_GET_INT
+            allowableValues = {OperationTypes.BIT_GET_INT}
     )
-    final public static String type = OperationTypes.BIT_GET_INT;
+    final public String type = OperationTypes.BIT_GET_INT;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -43,9 +43,13 @@ public class BitGetIntOperation extends BitOperation {
     private final boolean signed;
 
     @JsonCreator
-    public BitGetIntOperation(@JsonProperty(value = "binName", required = true) String binName,
-                              @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                              @JsonProperty(value = "bitSize", required = true) int bitSize, @JsonProperty(
+    public BitGetIntOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(
             value = "signed", defaultValue = "false"
     ) boolean signed) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitGetOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitGetOperation.java
@@ -30,9 +30,9 @@ public class BitGetOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_GET,
             required = true,
-            allowableValues = OperationTypes.BIT_GET
+            allowableValues = {OperationTypes.BIT_GET}
     )
-    final public static String type = OperationTypes.BIT_GET;
+    final public String type = OperationTypes.BIT_GET;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -41,9 +41,13 @@ public class BitGetOperation extends BitOperation {
     private final int bitSize;
 
     @JsonCreator
-    public BitGetOperation(@JsonProperty(value = "binName", required = true) String binName,
-                           @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                           @JsonProperty(value = "bitSize", required = true) int bitSize) {
+    public BitGetOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitInsertOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitInsertOperation.java
@@ -31,9 +31,9 @@ public class BitInsertOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_INSERT,
             required = true,
-            allowableValues = OperationTypes.BIT_INSERT
+            allowableValues = {OperationTypes.BIT_INSERT}
     )
-    final public static String type = OperationTypes.BIT_INSERT;
+    final public String type = OperationTypes.BIT_INSERT;
 
     @Schema(required = true)
     private final int byteOffset;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitLScanOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitLScanOperation.java
@@ -30,9 +30,9 @@ public class BitLScanOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_LSCAN,
             required = true,
-            allowableValues = OperationTypes.BIT_LSCAN
+            allowableValues = {OperationTypes.BIT_LSCAN}
     )
-    final public static String type = OperationTypes.BIT_LSCAN;
+    final public String type = OperationTypes.BIT_LSCAN;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -44,10 +44,15 @@ public class BitLScanOperation extends BitOperation {
     private final boolean value;
 
     @JsonCreator
-    public BitLScanOperation(@JsonProperty(value = "binName", required = true) String binName,
-                             @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                             @JsonProperty(value = "bitSize", required = true) int bitSize,
-                             @JsonProperty(value = "value", required = true) boolean value) {
+    public BitLScanOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) boolean value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitLShiftOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitLShiftOperation.java
@@ -31,9 +31,9 @@ public class BitLShiftOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_LSHIFT,
             required = true,
-            allowableValues = OperationTypes.BIT_LSHIFT
+            allowableValues = {OperationTypes.BIT_LSHIFT}
     )
-    final public static String type = OperationTypes.BIT_LSHIFT;
+    final public String type = OperationTypes.BIT_LSHIFT;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -45,10 +45,15 @@ public class BitLShiftOperation extends BitOperation {
     private final int shift;
 
     @JsonCreator
-    public BitLShiftOperation(@JsonProperty(value = "binName", required = true) String binName,
-                              @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                              @JsonProperty(value = "bitSize", required = true) int bitSize,
-                              @JsonProperty(value = "shift", required = true) int shift) {
+    public BitLShiftOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "shift") @Schema(
+            name = "shift", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int shift) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitLShiftOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitLShiftOperation.java
@@ -30,18 +30,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class BitLShiftOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_LSHIFT,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.BIT_LSHIFT}
     )
     final public String type = OperationTypes.BIT_LSHIFT;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int bitOffset;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int bitSize;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int shift;
 
     @JsonCreator

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitNotOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitNotOperation.java
@@ -31,9 +31,9 @@ public class BitNotOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_NOT,
             required = true,
-            allowableValues = OperationTypes.BIT_NOT
+            allowableValues = {OperationTypes.BIT_NOT}
     )
-    final public static String type = OperationTypes.BIT_NOT;
+    final public String type = OperationTypes.BIT_NOT;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -42,9 +42,13 @@ public class BitNotOperation extends BitOperation {
     private final int bitSize;
 
     @JsonCreator
-    public BitNotOperation(@JsonProperty(value = "binName", required = true) String binName,
-                           @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                           @JsonProperty(value = "bitSize", required = true) int bitSize) {
+    public BitNotOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitOperation.java
@@ -74,7 +74,9 @@ abstract public class BitOperation extends Operation {
     protected String binName;
 
     @JsonCreator
-    protected BitOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    protected BitOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         this.binName = binName;
     }
 }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitOrOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitOrOperation.java
@@ -31,9 +31,9 @@ public class BitOrOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_OR,
             required = true,
-            allowableValues = OperationTypes.BIT_OR
+            allowableValues = {OperationTypes.BIT_OR}
     )
-    final public static String type = OperationTypes.BIT_OR;
+    final public String type = OperationTypes.BIT_OR;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -45,10 +45,15 @@ public class BitOrOperation extends BitOperation {
     private final byte[] value;
 
     @JsonCreator
-    public BitOrOperation(@JsonProperty(value = "binName", required = true) String binName,
-                          @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                          @JsonProperty(value = "bitSize", required = true) int bitSize,
-                          @JsonProperty(value = "value", required = true) byte[] value) {
+    public BitOrOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) byte[] value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitRScanOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitRScanOperation.java
@@ -30,9 +30,9 @@ public class BitRScanOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_RSCAN,
             required = true,
-            allowableValues = OperationTypes.BIT_RSCAN
+            allowableValues = {OperationTypes.BIT_RSCAN}
     )
-    final public static String type = OperationTypes.BIT_RSCAN;
+    final public String type = OperationTypes.BIT_RSCAN;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -44,10 +44,13 @@ public class BitRScanOperation extends BitOperation {
     private final boolean value;
 
     @JsonCreator
-    public BitRScanOperation(@JsonProperty(value = "binName", required = true) String binName,
-                             @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                             @JsonProperty(value = "bitSize", required = true) int bitSize,
-                             @JsonProperty(value = "value", defaultValue = "false") boolean value) {
+    public BitRScanOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value", defaultValue = "false") boolean value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitRShiftOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitRShiftOperation.java
@@ -31,9 +31,9 @@ public class BitRShiftOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_LSHIFT,
             required = true,
-            allowableValues = OperationTypes.BIT_LSHIFT
+            allowableValues = {OperationTypes.BIT_LSHIFT}
     )
-    final public static String type = OperationTypes.BIT_LSHIFT;
+    final public String type = OperationTypes.BIT_LSHIFT;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -45,10 +45,15 @@ public class BitRShiftOperation extends BitOperation {
     private final int shift;
 
     @JsonCreator
-    public BitRShiftOperation(@JsonProperty(value = "binName", required = true) String binName,
-                              @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                              @JsonProperty(value = "bitSize", required = true) int bitSize,
-                              @JsonProperty(value = "shift", required = true) int shift) {
+    public BitRShiftOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "shift") @Schema(
+            name = "shift", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int shift) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitRemoveOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitRemoveOperation.java
@@ -31,9 +31,9 @@ public class BitRemoveOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_REMOVE,
             required = true,
-            allowableValues = OperationTypes.BIT_REMOVE
+            allowableValues = {OperationTypes.BIT_REMOVE}
     )
-    final public static String type = OperationTypes.BIT_REMOVE;
+    final public String type = OperationTypes.BIT_REMOVE;
 
     @Schema(required = true)
     private final int byteOffset;
@@ -42,9 +42,13 @@ public class BitRemoveOperation extends BitOperation {
     private final int byteSize;
 
     @JsonCreator
-    public BitRemoveOperation(@JsonProperty(value = "binName", required = true) String binName,
-                              @JsonProperty(value = "byteOffset", required = true) int byteOffset,
-                              @JsonProperty(value = "byteSize", required = true) int byteSize) {
+    public BitRemoveOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "byteOffset") @Schema(
+            name = "byteOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int byteOffset, @JsonProperty(value = "byteSize") @Schema(
+            name = "byteSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int byteSize) {
         super(binName);
         this.byteOffset = byteOffset;
         this.byteSize = byteSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitResizeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitResizeOperation.java
@@ -31,9 +31,9 @@ public class BitResizeOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_RESIZE,
             required = true,
-            allowableValues = OperationTypes.BIT_RESIZE
+            allowableValues = {OperationTypes.BIT_RESIZE}
     )
-    final public static String type = OperationTypes.BIT_RESIZE;
+    final public String type = OperationTypes.BIT_RESIZE;
 
     @Schema(required = true)
     private final int byteSize;
@@ -42,9 +42,13 @@ public class BitResizeOperation extends BitOperation {
     private final int resizeFlags;
 
     @JsonCreator
-    public BitResizeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                              @JsonProperty(value = "byteSize", required = true) int byteSize,
-                              @JsonProperty(value = "resizeFlags", required = true) int resizeFlags) {
+    public BitResizeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "byteSize") @Schema(
+            name = "byteSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int byteSize, @Schema(
+            name = "resizeFlags", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int resizeFlags) {
         super(binName);
         this.byteSize = byteSize;
         this.resizeFlags = resizeFlags;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitSetIntOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitSetIntOperation.java
@@ -31,9 +31,9 @@ public class BitSetIntOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_SET_INT,
             required = true,
-            allowableValues = OperationTypes.BIT_SET_INT
+            allowableValues = {OperationTypes.BIT_SET_INT}
     )
-    final public static String type = OperationTypes.BIT_SET_INT;
+    final public String type = OperationTypes.BIT_SET_INT;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -45,10 +45,15 @@ public class BitSetIntOperation extends BitOperation {
     private final long value;
 
     @JsonCreator
-    public BitSetIntOperation(@JsonProperty(value = "binName", required = true) String binName,
-                              @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                              @JsonProperty(value = "bitSize", required = true) int bitSize,
-                              @JsonProperty(value = "value", required = true) long value) {
+    public BitSetIntOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) long value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitSetOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitSetOperation.java
@@ -31,9 +31,9 @@ public class BitSetOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_SET,
             required = true,
-            allowableValues = OperationTypes.BIT_SET
+            allowableValues = {OperationTypes.BIT_SET}
     )
-    final public static String type = OperationTypes.BIT_SET;
+    final public String type = OperationTypes.BIT_SET;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -45,10 +45,15 @@ public class BitSetOperation extends BitOperation {
     private final byte[] value;
 
     @JsonCreator
-    public BitSetOperation(@JsonProperty(value = "binName", required = true) String binName,
-                           @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                           @JsonProperty(value = "bitSize", required = true) int bitSize,
-                           @JsonProperty(value = "value", required = true) byte[] value) {
+    public BitSetOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) byte[] value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitSubtractOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitSubtractOperation.java
@@ -32,9 +32,9 @@ public class BitSubtractOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_SUBTRACT,
             required = true,
-            allowableValues = OperationTypes.BIT_SUBTRACT
+            allowableValues = {OperationTypes.BIT_SUBTRACT}
     )
-    final public static String type = OperationTypes.BIT_SUBTRACT;
+    final public String type = OperationTypes.BIT_SUBTRACT;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -51,10 +51,15 @@ public class BitSubtractOperation extends BitOperation {
     private BitOverflowAction action = BitOverflowAction.FAIL;
 
     @JsonCreator
-    public BitSubtractOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                                @JsonProperty(value = "bitSize", required = true) int bitSize,
-                                @JsonProperty(value = "value", required = true) long value) {
+    public BitSubtractOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) long value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/BitXOrOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/BitXOrOperation.java
@@ -31,9 +31,9 @@ public class BitXOrOperation extends BitOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.BIT_XOR,
             required = true,
-            allowableValues = OperationTypes.BIT_XOR
+            allowableValues = {OperationTypes.BIT_XOR}
     )
-    final public static String type = OperationTypes.BIT_XOR;
+    final public String type = OperationTypes.BIT_XOR;
 
     @Schema(required = true)
     private final int bitOffset;
@@ -45,10 +45,15 @@ public class BitXOrOperation extends BitOperation {
     private final byte[] value;
 
     @JsonCreator
-    public BitXOrOperation(@JsonProperty(value = "binName", required = true) String binName,
-                           @JsonProperty(value = "bitOffset", required = true) int bitOffset,
-                           @JsonProperty(value = "bitSize", required = true) int bitSize,
-                           @JsonProperty(value = "value", required = true) byte[] value) {
+    public BitXOrOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "bitOffset") @Schema(
+            name = "bitOffset", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitOffset, @JsonProperty(value = "bitSize") @Schema(
+            name = "bitSize", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int bitSize, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) byte[] value) {
         super(binName);
         this.bitOffset = bitOffset;
         this.bitSize = bitSize;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/DeleteOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/DeleteOperation.java
@@ -29,9 +29,9 @@ public class DeleteOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.DELETE,
             required = true,
-            allowableValues = OperationTypes.DELETE
+            allowableValues = {OperationTypes.DELETE}
     )
-    final public static String type = OperationTypes.DELETE;
+    final public String type = OperationTypes.DELETE;
 
     @Override
     public com.aerospike.client.Operation toOperation() {

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/DeleteOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/DeleteOperation.java
@@ -28,7 +28,7 @@ public class DeleteOperation extends Operation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.DELETE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.DELETE}
     )
     final public String type = OperationTypes.DELETE;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/GetHeaderOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/GetHeaderOperation.java
@@ -29,9 +29,9 @@ public class GetHeaderOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.GET_HEADER,
             required = true,
-            allowableValues = OperationTypes.GET_HEADER
+            allowableValues = {OperationTypes.GET_HEADER}
     )
-    final public static String type = OperationTypes.GET_HEADER;
+    final public String type = OperationTypes.GET_HEADER;
 
     @Override
     public com.aerospike.client.Operation toOperation() {

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/GetOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/GetOperation.java
@@ -31,9 +31,9 @@ public class GetOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.GET,
             required = true,
-            allowableValues = OperationTypes.GET
+            allowableValues = {OperationTypes.GET}
     )
-    final public static String type = OperationTypes.GET;
+    final public String type = OperationTypes.GET;
 
     private final String binName;
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLAddOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLAddOperation.java
@@ -34,9 +34,9 @@ public class HLLAddOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_ADD,
             required = true,
-            allowableValues = OperationTypes.HLL_ADD
+            allowableValues = {OperationTypes.HLL_ADD}
     )
-    final public static String type = OperationTypes.HLL_ADD;
+    final public String type = OperationTypes.HLL_ADD;
 
     @Schema(required = true)
     private final List<Object> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLDescribeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLDescribeOperation.java
@@ -31,12 +31,14 @@ public class HLLDescribeOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_DESCRIBE,
             required = true,
-            allowableValues = OperationTypes.HLL_DESCRIBE
+            allowableValues = {OperationTypes.HLL_DESCRIBE}
     )
-    final public static String type = OperationTypes.HLL_DESCRIBE;
+    final public String type = OperationTypes.HLL_DESCRIBE;
 
     @JsonCreator
-    public HLLDescribeOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public HLLDescribeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         super(binName);
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLFoldOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLFoldOperation.java
@@ -29,12 +29,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class HLLFoldOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_FOLD,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.HLL_FOLD}
     )
     final public String type = OperationTypes.HLL_FOLD;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int indexBitCount;
 
     @JsonCreator

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLFoldOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLFoldOperation.java
@@ -30,16 +30,19 @@ public class HLLFoldOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_FOLD,
             required = true,
-            allowableValues = OperationTypes.HLL_FOLD
+            allowableValues = {OperationTypes.HLL_FOLD}
     )
-    final public static String type = OperationTypes.HLL_FOLD;
+    final public String type = OperationTypes.HLL_FOLD;
 
     @Schema(required = true)
     private final int indexBitCount;
 
     @JsonCreator
-    public HLLFoldOperation(@JsonProperty(value = "binName", required = true) String binName,
-                            @JsonProperty(value = "indexBitCount", required = true) int indexBitCount) {
+    public HLLFoldOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @Schema(
+            name = "indexBitCount", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int indexBitCount) {
         super(binName);
         this.indexBitCount = indexBitCount;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetCountOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetCountOperation.java
@@ -30,12 +30,14 @@ public class HLLGetCountOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_COUNT,
             required = true,
-            allowableValues = OperationTypes.HLL_COUNT
+            allowableValues = {OperationTypes.HLL_COUNT}
     )
-    final public static String type = OperationTypes.HLL_COUNT;
+    final public String type = OperationTypes.HLL_COUNT;
 
     @JsonCreator
-    public HLLGetCountOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public HLLGetCountOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         super(binName);
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetIntersectionCountOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetIntersectionCountOperation.java
@@ -33,9 +33,9 @@ public class HLLGetIntersectionCountOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_INTERSECT_COUNT,
             required = true,
-            allowableValues = OperationTypes.HLL_INTERSECT_COUNT
+            allowableValues = {OperationTypes.HLL_INTERSECT_COUNT}
     )
-    final public static String type = OperationTypes.HLL_INTERSECT_COUNT;
+    final public String type = OperationTypes.HLL_INTERSECT_COUNT;
 
     @Schema(required = true)
     private final List<byte[]> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetSimilarityOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetSimilarityOperation.java
@@ -33,9 +33,9 @@ public class HLLGetSimilarityOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_SIMILARITY,
             required = true,
-            allowableValues = OperationTypes.HLL_SIMILARITY
+            allowableValues = {OperationTypes.HLL_SIMILARITY}
     )
-    final public static String type = OperationTypes.HLL_SIMILARITY;
+    final public String type = OperationTypes.HLL_SIMILARITY;
 
     @Schema(required = true)
     private final List<byte[]> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetUnionCountOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetUnionCountOperation.java
@@ -33,9 +33,9 @@ public class HLLGetUnionCountOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_UNION_COUNT,
             required = true,
-            allowableValues = OperationTypes.HLL_UNION_COUNT
+            allowableValues = {OperationTypes.HLL_UNION_COUNT}
     )
-    final public static String type = OperationTypes.HLL_UNION_COUNT;
+    final public String type = OperationTypes.HLL_UNION_COUNT;
 
     @Schema(required = true)
     private final List<byte[]> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetUnionOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLGetUnionOperation.java
@@ -33,9 +33,9 @@ public class HLLGetUnionOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_UNION,
             required = true,
-            allowableValues = OperationTypes.HLL_UNION
+            allowableValues = {OperationTypes.HLL_UNION}
     )
-    final public static String type = OperationTypes.HLL_UNION;
+    final public String type = OperationTypes.HLL_UNION;
 
     @Schema(required = true)
     private final List<byte[]> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLInitOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLInitOperation.java
@@ -31,9 +31,9 @@ public class HLLInitOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_INIT,
             required = true,
-            allowableValues = OperationTypes.HLL_INIT
+            allowableValues = {OperationTypes.HLL_INIT}
     )
-    final public static String type = OperationTypes.HLL_INIT;
+    final public String type = OperationTypes.HLL_INIT;
 
     @Schema(required = true)
     private final int indexBitCount;
@@ -41,8 +41,11 @@ public class HLLInitOperation extends HLLOperation {
     private Integer minHashBitCount;
 
     @JsonCreator
-    public HLLInitOperation(@JsonProperty(value = "binName", required = true) String binName,
-                            @JsonProperty(value = "indexBitCount", required = true) int indexBitCount) {
+    public HLLInitOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @Schema(
+            name = "indexBitCount", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int indexBitCount) {
         super(binName);
         this.indexBitCount = indexBitCount;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLRefreshCountOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLRefreshCountOperation.java
@@ -30,12 +30,14 @@ public class HLLRefreshCountOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_SET_COUNT,
             required = true,
-            allowableValues = OperationTypes.HLL_SET_UNION
+            allowableValues = {OperationTypes.HLL_SET_UNION}
     )
-    final public static String type = OperationTypes.HLL_SET_UNION;
+    final public String type = OperationTypes.HLL_SET_UNION;
 
     @JsonCreator
-    public HLLRefreshCountOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public HLLRefreshCountOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         super(binName);
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLSetUnionOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/HLLSetUnionOperation.java
@@ -34,9 +34,9 @@ public class HLLSetUnionOperation extends HLLOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.HLL_SET_UNION,
             required = true,
-            allowableValues = OperationTypes.HLL_SET_UNION
+            allowableValues = {OperationTypes.HLL_SET_UNION}
     )
-    final public static String type = OperationTypes.HLL_SET_UNION;
+    final public String type = OperationTypes.HLL_SET_UNION;
 
     @Schema(required = true)
     private final List<byte[]> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListAppendItemsOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListAppendItemsOperation.java
@@ -37,9 +37,9 @@ public class ListAppendItemsOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_APPEND_ITEMS,
             required = true,
-            allowableValues = OperationTypes.LIST_APPEND_ITEMS
+            allowableValues = {OperationTypes.LIST_APPEND_ITEMS}
     )
-    final public static String type = OperationTypes.LIST_APPEND_ITEMS;
+    final public String type = OperationTypes.LIST_APPEND_ITEMS;
 
     @Schema(required = true)
     private final List<Object> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListAppendOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListAppendOperation.java
@@ -32,9 +32,9 @@ public class ListAppendOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_APPEND,
             required = true,
-            allowableValues = OperationTypes.LIST_APPEND
+            allowableValues = {OperationTypes.LIST_APPEND}
     )
-    final public static String type = OperationTypes.LIST_APPEND;
+    final public String type = OperationTypes.LIST_APPEND;
 
     @Schema(required = true)
     private final Object value;
@@ -43,8 +43,11 @@ public class ListAppendOperation extends ListOperation {
     private ListPolicy listPolicy;
 
     @JsonCreator
-    public ListAppendOperation(@JsonProperty(value = "binName", required = true) String binName,
-                               @JsonProperty(value = "value", required = true) Object value) {
+    public ListAppendOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value) {
         super(binName);
         this.value = value;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListClearOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListClearOperation.java
@@ -31,12 +31,14 @@ public class ListClearOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_CLEAR,
             required = true,
-            allowableValues = OperationTypes.LIST_CLEAR
+            allowableValues = {OperationTypes.LIST_CLEAR}
     )
-    final public static String type = OperationTypes.LIST_CLEAR;
+    final public String type = OperationTypes.LIST_CLEAR;
 
     @JsonCreator
-    public ListClearOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public ListClearOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         super(binName);
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListCreateOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListCreateOperation.java
@@ -32,9 +32,9 @@ public class ListCreateOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_CREATE,
             required = true,
-            allowableValues = OperationTypes.LIST_CREATE
+            allowableValues = {OperationTypes.LIST_CREATE}
     )
-    final public static String type = OperationTypes.LIST_CREATE;
+    final public String type = OperationTypes.LIST_CREATE;
 
     @Schema(required = true)
     private final ListOrder order;
@@ -42,8 +42,11 @@ public class ListCreateOperation extends ListOperation {
     private boolean pad;
 
     @JsonCreator
-    public ListCreateOperation(@JsonProperty(value = "binName", required = true) String binName,
-                               @JsonProperty(value = "order", required = true) ListOrder order) {
+    public ListCreateOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "order") @Schema(
+            name = "order", requiredMode = Schema.RequiredMode.REQUIRED
+    ) ListOrder order) {
         super(binName);
         this.order = order;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByIndexOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByIndexOperation.java
@@ -31,9 +31,9 @@ public class ListGetByIndexOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_INDEX,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_BY_INDEX
+            allowableValues = {OperationTypes.LIST_GET_BY_INDEX}
     )
-    final public static String type = OperationTypes.LIST_GET_BY_INDEX;
+    final public String type = OperationTypes.LIST_GET_BY_INDEX;
 
     @Schema(required = true)
     private final int index;
@@ -44,8 +44,11 @@ public class ListGetByIndexOperation extends ListOperation {
     private boolean inverted;
 
     @JsonCreator
-    public ListGetByIndexOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                   @JsonProperty(value = "index", required = true) int index, @JsonProperty(
+    public ListGetByIndexOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);
@@ -64,6 +67,7 @@ public class ListGetByIndexOperation extends ListOperation {
     @Override
     public com.aerospike.client.Operation toOperation() {
         com.aerospike.client.cdt.CTX[] asCTX = getASCTX();
-        return com.aerospike.client.cdt.ListOperation.getByIndex(binName, index, listReturnType.toListReturnType(inverted), asCTX);
+        return com.aerospike.client.cdt.ListOperation.getByIndex(binName, index,
+                listReturnType.toListReturnType(inverted), asCTX);
     }
 }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByIndexOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByIndexOperation.java
@@ -30,15 +30,15 @@ public class ListGetByIndexOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_INDEX,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_GET_BY_INDEX}
     )
     final public String type = OperationTypes.LIST_GET_BY_INDEX;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int index;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final ListReturnType listReturnType;
 
     private boolean inverted;
@@ -49,7 +49,9 @@ public class ListGetByIndexOperation extends ListOperation {
     ) String binName, @JsonProperty(value = "index") @Schema(
             name = "index", requiredMode = Schema.RequiredMode.REQUIRED
     ) int index, @JsonProperty(
-            value = "listReturnType", required = true
+            value = "listReturnType"
+    ) @Schema(
+            name = "listReturnType", requiredMode = Schema.RequiredMode.REQUIRED
     ) ListReturnType listReturnType) {
         super(binName);
         this.index = index;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByIndexRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByIndexRangeOperation.java
@@ -31,9 +31,9 @@ public class ListGetByIndexRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_INDEX_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_BY_INDEX_RANGE
+            allowableValues = {OperationTypes.LIST_GET_BY_INDEX_RANGE}
     )
-    final public static String type = OperationTypes.LIST_GET_BY_INDEX_RANGE;
+    final public String type = OperationTypes.LIST_GET_BY_INDEX_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -46,8 +46,11 @@ public class ListGetByIndexRangeOperation extends ListOperation {
     private Integer count;
 
     @JsonCreator
-    public ListGetByIndexRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                        @JsonProperty(value = "index", required = true) int index, @JsonProperty(
+    public ListGetByIndexRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByRankOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByRankOperation.java
@@ -31,9 +31,9 @@ public class ListGetByRankOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_RANK,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_BY_RANK
+            allowableValues = {OperationTypes.LIST_GET_BY_RANK}
     )
-    final public static String type = OperationTypes.LIST_GET_BY_RANK;
+    final public String type = OperationTypes.LIST_GET_BY_RANK;
 
     @Schema(required = true)
     private final int rank;
@@ -44,8 +44,11 @@ public class ListGetByRankOperation extends ListOperation {
     private boolean inverted;
 
     @JsonCreator
-    public ListGetByRankOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                  @JsonProperty(value = "rank", required = true) int rank, @JsonProperty(
+    public ListGetByRankOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);
@@ -64,6 +67,7 @@ public class ListGetByRankOperation extends ListOperation {
     @Override
     public com.aerospike.client.Operation toOperation() {
         com.aerospike.client.cdt.CTX[] asCTX = getASCTX();
-        return com.aerospike.client.cdt.ListOperation.getByRank(binName, rank, listReturnType.toListReturnType(inverted), asCTX);
+        return com.aerospike.client.cdt.ListOperation.getByRank(binName, rank,
+                listReturnType.toListReturnType(inverted), asCTX);
     }
 }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByRankRangeOperation.java
@@ -31,9 +31,9 @@ public class ListGetByRankRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_RANK_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_BY_RANK_RANGE
+            allowableValues = {OperationTypes.LIST_GET_BY_RANK_RANGE}
     )
-    final public static String type = OperationTypes.LIST_GET_BY_RANK_RANGE;
+    final public String type = OperationTypes.LIST_GET_BY_RANK_RANGE;
 
     @Schema(required = true)
     private final int rank;
@@ -45,8 +45,11 @@ public class ListGetByRankRangeOperation extends ListOperation {
     private Integer count;
 
     @JsonCreator
-    public ListGetByRankRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                       @JsonProperty(value = "rank", required = true) int rank, @JsonProperty(
+    public ListGetByRankRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueListOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueListOperation.java
@@ -34,9 +34,9 @@ public class ListGetByValueListOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_VALUE_LIST,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_BY_VALUE_LIST
+            allowableValues = {OperationTypes.LIST_GET_BY_VALUE_LIST}
     )
-    final public static String type = OperationTypes.LIST_GET_BY_VALUE_LIST;
+    final public String type = OperationTypes.LIST_GET_BY_VALUE_LIST;
 
     @Schema(required = true)
     private final ListReturnType listReturnType;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueOperation.java
@@ -32,9 +32,9 @@ public class ListGetByValueOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_VALUE,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_BY_VALUE
+            allowableValues = {OperationTypes.LIST_GET_BY_VALUE}
     )
-    final public static String type = OperationTypes.LIST_GET_BY_VALUE;
+    final public String type = OperationTypes.LIST_GET_BY_VALUE;
 
     @Schema(required = true)
     private final Object value;
@@ -45,8 +45,11 @@ public class ListGetByValueOperation extends ListOperation {
     private boolean inverted;
 
     @JsonCreator
-    public ListGetByValueOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                   @JsonProperty(value = "value", required = true) Object value, @JsonProperty(
+    public ListGetByValueOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);
@@ -67,6 +70,7 @@ public class ListGetByValueOperation extends ListOperation {
     public com.aerospike.client.Operation toOperation() {
         com.aerospike.client.cdt.CTX[] asCTX = getASCTX();
 
-        return com.aerospike.client.cdt.ListOperation.getByValue(binName, Value.get(value), listReturnType.toListReturnType(inverted), asCTX);
+        return com.aerospike.client.cdt.ListOperation.getByValue(binName, Value.get(value),
+                listReturnType.toListReturnType(inverted), asCTX);
     }
 }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueOperation.java
@@ -31,15 +31,15 @@ public class ListGetByValueOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_VALUE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_GET_BY_VALUE}
     )
     final public String type = OperationTypes.LIST_GET_BY_VALUE;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final Object value;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final ListReturnType listReturnType;
 
     private boolean inverted;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueRangeOperation.java
@@ -34,9 +34,9 @@ public class ListGetByValueRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_VALUE_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_BY_VALUE_RANGE
+            allowableValues = {OperationTypes.LIST_GET_BY_VALUE_RANGE}
     )
-    final public static String type = OperationTypes.LIST_GET_BY_VALUE_RANGE;
+    final public String type = OperationTypes.LIST_GET_BY_VALUE_RANGE;
 
     @Schema(required = true)
     private final ListReturnType listReturnType;
@@ -48,7 +48,9 @@ public class ListGetByValueRangeOperation extends ListOperation {
     private Object valueEnd;
 
     @JsonCreator
-    public ListGetByValueRangeOperation(@JsonProperty(value = "binName", required = true) String binName, @JsonProperty(
+    public ListGetByValueRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueRelativeRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueRelativeRankRangeOperation.java
@@ -31,18 +31,18 @@ public class ListGetByValueRelativeRankRangeOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_VALUE_RELATIVE_RANK_RANGE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_GET_BY_VALUE_RELATIVE_RANK_RANGE}
     )
     final public String type = OperationTypes.LIST_GET_BY_VALUE_RELATIVE_RANK_RANGE;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int rank;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final Object value;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final ListReturnType listReturnType;
 
     private boolean inverted;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueRelativeRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetByValueRelativeRankRangeOperation.java
@@ -32,9 +32,9 @@ public class ListGetByValueRelativeRankRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_BY_VALUE_RELATIVE_RANK_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_BY_VALUE_RELATIVE_RANK_RANGE
+            allowableValues = {OperationTypes.LIST_GET_BY_VALUE_RELATIVE_RANK_RANGE}
     )
-    final public static String type = OperationTypes.LIST_GET_BY_VALUE_RELATIVE_RANK_RANGE;
+    final public String type = OperationTypes.LIST_GET_BY_VALUE_RELATIVE_RANK_RANGE;
 
     @Schema(required = true)
     private final int rank;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetOperation.java
@@ -31,16 +31,19 @@ public class ListGetOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET,
             required = true,
-            allowableValues = OperationTypes.LIST_GET
+            allowableValues = {OperationTypes.LIST_GET}
     )
-    final public static String type = OperationTypes.LIST_GET;
+    final public String type = OperationTypes.LIST_GET;
 
     @Schema(required = true)
     private final int index;
 
     @JsonCreator
-    public ListGetOperation(@JsonProperty(value = "binName", required = true) String binName,
-                            @JsonProperty(value = "index", required = true) int index) {
+    public ListGetOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index) {
         super(binName);
         this.index = index;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetOperation.java
@@ -30,12 +30,12 @@ public class ListGetOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_GET}
     )
     final public String type = OperationTypes.LIST_GET;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int index;
 
     @JsonCreator

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetRangeOperation.java
@@ -31,9 +31,9 @@ public class ListGetRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_GET_RANGE
+            allowableValues = {OperationTypes.LIST_GET_RANGE}
     )
-    final public static String type = OperationTypes.LIST_GET_RANGE;
+    final public String type = OperationTypes.LIST_GET_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -41,8 +41,11 @@ public class ListGetRangeOperation extends ListOperation {
     private Integer count;
 
     @JsonCreator
-    public ListGetRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                 @JsonProperty(value = "index", required = true) int index) {
+    public ListGetRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index) {
         super(binName);
         this.index = index;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListGetRangeOperation.java
@@ -30,12 +30,12 @@ public class ListGetRangeOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_GET_RANGE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_GET_RANGE}
     )
     final public String type = OperationTypes.LIST_GET_RANGE;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int index;
 
     private Integer count;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListIncrementOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListIncrementOperation.java
@@ -32,9 +32,9 @@ public class ListIncrementOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_INCREMENT,
             required = true,
-            allowableValues = OperationTypes.LIST_INCREMENT
+            allowableValues = {OperationTypes.LIST_INCREMENT}
     )
-    final public static String type = OperationTypes.LIST_INCREMENT;
+    final public String type = OperationTypes.LIST_INCREMENT;
 
     @Schema(required = true)
     private final int index;
@@ -45,9 +45,13 @@ public class ListIncrementOperation extends ListOperation {
     private ListPolicy listPolicy;
 
     @JsonCreator
-    public ListIncrementOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                  @JsonProperty(value = "index", required = true) int index,
-                                  @JsonProperty(value = "incr", required = true) Number incr) {
+    public ListIncrementOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(value = "incr") @Schema(
+            name = "incr", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Number incr) {
         super(binName);
         this.index = index;
         this.incr = incr;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListInsertItemsOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListInsertItemsOperation.java
@@ -34,9 +34,9 @@ public class ListInsertItemsOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_INSERT_ITEMS,
             required = true,
-            allowableValues = OperationTypes.LIST_INSERT_ITEMS
+            allowableValues = {OperationTypes.LIST_INSERT_ITEMS}
     )
-    final public static String type = OperationTypes.LIST_INSERT_ITEMS;
+    final public String type = OperationTypes.LIST_INSERT_ITEMS;
 
     @Schema(required = true)
     private final int index;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListInsertOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListInsertOperation.java
@@ -32,9 +32,9 @@ public class ListInsertOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_INSERT,
             required = true,
-            allowableValues = OperationTypes.LIST_INSERT
+            allowableValues = {OperationTypes.LIST_INSERT}
     )
-    final public static String type = OperationTypes.LIST_INSERT;
+    final public String type = OperationTypes.LIST_INSERT;
 
     @Schema(required = true)
     private final int index;
@@ -45,9 +45,13 @@ public class ListInsertOperation extends ListOperation {
     private ListPolicy listPolicy;
 
     @JsonCreator
-    public ListInsertOperation(@JsonProperty(value = "binName", required = true) String binName,
-                               @JsonProperty(value = "index", required = true) int index,
-                               @JsonProperty(value = "value", required = true) Object value) {
+    public ListInsertOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value) {
         super(binName);
         this.index = index;
         this.value = value;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListOperation.java
@@ -149,7 +149,9 @@ abstract public class ListOperation extends Operation {
     protected List<CTX> ctx;
 
     @JsonCreator
-    protected ListOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    protected ListOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         this.binName = binName;
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListPopOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListPopOperation.java
@@ -31,16 +31,19 @@ public class ListPopOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_POP,
             required = true,
-            allowableValues = OperationTypes.LIST_POP
+            allowableValues = {OperationTypes.LIST_POP}
     )
-    final public static String type = OperationTypes.LIST_POP;
+    final public String type = OperationTypes.LIST_POP;
 
     @Schema(required = true)
     private final int index;
 
     @JsonCreator
-    public ListPopOperation(@JsonProperty(value = "binName", required = true) String binName,
-                            @JsonProperty(value = "index", required = true) int index) {
+    public ListPopOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index) {
         super(binName);
         this.index = index;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListPopRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListPopRangeOperation.java
@@ -30,12 +30,12 @@ public class ListPopRangeOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_POP_RANGE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_POP_RANGE}
     )
     final public String type = OperationTypes.LIST_POP_RANGE;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int index;
 
     private Integer count;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListPopRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListPopRangeOperation.java
@@ -31,9 +31,9 @@ public class ListPopRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_POP_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_POP_RANGE
+            allowableValues = {OperationTypes.LIST_POP_RANGE}
     )
-    final public static String type = OperationTypes.LIST_POP_RANGE;
+    final public String type = OperationTypes.LIST_POP_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -41,8 +41,11 @@ public class ListPopRangeOperation extends ListOperation {
     private Integer count;
 
     @JsonCreator
-    public ListPopRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                 @JsonProperty(value = "index", required = true) int index) {
+    public ListPopRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index) {
         super(binName);
         this.index = index;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByIndexOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByIndexOperation.java
@@ -31,9 +31,9 @@ public class ListRemoveByIndexOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_INDEX,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_BY_INDEX
+            allowableValues = {OperationTypes.LIST_REMOVE_BY_INDEX}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_BY_INDEX;
+    final public String type = OperationTypes.LIST_REMOVE_BY_INDEX;
 
     @Schema(required = true)
     private final int index;
@@ -44,8 +44,11 @@ public class ListRemoveByIndexOperation extends ListOperation {
     private boolean inverted;
 
     @JsonCreator
-    public ListRemoveByIndexOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                      @JsonProperty(value = "index", required = true) int index, @JsonProperty(
+    public ListRemoveByIndexOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByIndexRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByIndexRangeOperation.java
@@ -31,9 +31,9 @@ public class ListRemoveByIndexRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_INDEX_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_BY_INDEX_RANGE
+            allowableValues = {OperationTypes.LIST_REMOVE_BY_INDEX_RANGE}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_BY_INDEX_RANGE;
+    final public String type = OperationTypes.LIST_REMOVE_BY_INDEX_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -46,8 +46,11 @@ public class ListRemoveByIndexRangeOperation extends ListOperation {
     private Integer count;
 
     @JsonCreator
-    public ListRemoveByIndexRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                           @JsonProperty(value = "index", required = true) int index, @JsonProperty(
+    public ListRemoveByIndexRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByRankOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByRankOperation.java
@@ -31,9 +31,9 @@ public class ListRemoveByRankOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_RANK,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_BY_RANK
+            allowableValues = {OperationTypes.LIST_REMOVE_BY_RANK}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_BY_RANK;
+    final public String type = OperationTypes.LIST_REMOVE_BY_RANK;
 
     @Schema(required = true)
     private final int rank;
@@ -44,8 +44,11 @@ public class ListRemoveByRankOperation extends ListOperation {
     private boolean inverted;
 
     @JsonCreator
-    public ListRemoveByRankOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                     @JsonProperty(value = "rank", required = true) int rank, @JsonProperty(
+    public ListRemoveByRankOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);
@@ -65,6 +68,7 @@ public class ListRemoveByRankOperation extends ListOperation {
     public com.aerospike.client.Operation toOperation() {
         com.aerospike.client.cdt.CTX[] asCTX = getASCTX();
 
-        return com.aerospike.client.cdt.ListOperation.removeByRank(binName, rank, listReturnType.toListReturnType(inverted), asCTX);
+        return com.aerospike.client.cdt.ListOperation.removeByRank(binName, rank,
+                listReturnType.toListReturnType(inverted), asCTX);
     }
 }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByRankOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByRankOperation.java
@@ -30,15 +30,15 @@ public class ListRemoveByRankOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_RANK,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_REMOVE_BY_RANK}
     )
     final public String type = OperationTypes.LIST_REMOVE_BY_RANK;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int rank;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final ListReturnType listReturnType;
 
     private boolean inverted;
@@ -49,7 +49,9 @@ public class ListRemoveByRankOperation extends ListOperation {
     ) String binName, @JsonProperty(value = "rank") @Schema(
             name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
     ) int rank, @JsonProperty(
-            value = "listReturnType", required = true
+            value = "listReturnType"
+    ) @Schema(
+            name = "listReturnType", requiredMode = Schema.RequiredMode.REQUIRED
     ) ListReturnType listReturnType) {
         super(binName);
         this.rank = rank;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByRankRangeOperation.java
@@ -31,9 +31,9 @@ public class ListRemoveByRankRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_RANK_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_BY_RANK_RANGE
+            allowableValues = {OperationTypes.LIST_REMOVE_BY_RANK_RANGE}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_BY_RANK_RANGE;
+    final public String type = OperationTypes.LIST_REMOVE_BY_RANK_RANGE;
 
     @Schema(required = true)
     private final int rank;
@@ -44,8 +44,11 @@ public class ListRemoveByRankRangeOperation extends ListOperation {
     private boolean inverted;
 
     @JsonCreator
-    public ListRemoveByRankRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                          @JsonProperty(value = "rank", required = true) int rank, @JsonProperty(
+    public ListRemoveByRankRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueListOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueListOperation.java
@@ -33,15 +33,15 @@ public class ListRemoveByValueListOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_VALUE_LIST,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_REMOVE_BY_VALUE_LIST}
     )
     final public String type = OperationTypes.LIST_REMOVE_BY_VALUE_LIST;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final List<Object> values;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final ListReturnType listReturnType;
 
     private boolean inverted;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueListOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueListOperation.java
@@ -34,9 +34,9 @@ public class ListRemoveByValueListOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_VALUE_LIST,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_BY_VALUE_LIST
+            allowableValues = {OperationTypes.LIST_REMOVE_BY_VALUE_LIST}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_BY_VALUE_LIST;
+    final public String type = OperationTypes.LIST_REMOVE_BY_VALUE_LIST;
 
     @Schema(required = true)
     private final List<Object> values;
@@ -68,6 +68,7 @@ public class ListRemoveByValueListOperation extends ListOperation {
         List<Value> asVals = values.stream().map(Value::get).toList();
         com.aerospike.client.cdt.CTX[] asCTX = getASCTX();
 
-        return com.aerospike.client.cdt.ListOperation.removeByValueList(binName, asVals, listReturnType.toListReturnType(inverted), asCTX);
+        return com.aerospike.client.cdt.ListOperation.removeByValueList(binName, asVals,
+                listReturnType.toListReturnType(inverted), asCTX);
     }
 }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueOperation.java
@@ -36,9 +36,9 @@ public class ListRemoveByValueOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_VALUE,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_BY_VALUE
+            allowableValues = {OperationTypes.LIST_REMOVE_BY_VALUE}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_BY_VALUE;
+    final public String type = OperationTypes.LIST_REMOVE_BY_VALUE;
 
     @Schema(required = true)
     private final Object value;
@@ -49,8 +49,11 @@ public class ListRemoveByValueOperation extends ListOperation {
     private boolean inverted;
 
     @JsonCreator
-    public ListRemoveByValueOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                      @JsonProperty(value = "value", required = true) Object value, @JsonProperty(
+    public ListRemoveByValueOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value, @JsonProperty(
             value = "listReturnType", required = true
     ) ListReturnType listReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueRangeOperation.java
@@ -32,9 +32,9 @@ public class ListRemoveByValueRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_VALUE_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_BY_VALUE_RANGE
+            allowableValues = {OperationTypes.LIST_REMOVE_BY_VALUE_RANGE}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_BY_VALUE_RANGE;
+    final public String type = OperationTypes.LIST_REMOVE_BY_VALUE_RANGE;
 
     @Schema(required = true)
     private final ListReturnType listReturnType;
@@ -46,10 +46,11 @@ public class ListRemoveByValueRangeOperation extends ListOperation {
     private Object valueEnd;
 
     @JsonCreator
-    public ListRemoveByValueRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                           @JsonProperty(
-                                                   value = "listReturnType", required = true
-                                           ) ListReturnType listReturnType) {
+    public ListRemoveByValueRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(
+            value = "listReturnType", required = true
+    ) ListReturnType listReturnType) {
         super(binName);
         this.listReturnType = listReturnType;
     }
@@ -92,6 +93,7 @@ public class ListRemoveByValueRangeOperation extends ListOperation {
             end = Value.get(valueEnd);
         }
 
-        return com.aerospike.client.cdt.ListOperation.removeByValueRange(binName, begin, end, listReturnType.toListReturnType(inverted), asCTX);
+        return com.aerospike.client.cdt.ListOperation.removeByValueRange(binName, begin, end,
+                listReturnType.toListReturnType(inverted), asCTX);
     }
 }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueRelativeRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveByValueRelativeRankRangeOperation.java
@@ -32,9 +32,9 @@ public class ListRemoveByValueRelativeRankRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE
+            allowableValues = {OperationTypes.LIST_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE;
+    final public String type = OperationTypes.LIST_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE;
 
     @Schema(required = true)
     private final int rank;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveOperation.java
@@ -31,16 +31,19 @@ public class ListRemoveOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE
+            allowableValues = {OperationTypes.LIST_REMOVE}
     )
-    final public static String type = OperationTypes.LIST_REMOVE;
+    final public String type = OperationTypes.LIST_REMOVE;
 
     @Schema(required = true)
     private final int index;
 
     @JsonCreator
-    public ListRemoveOperation(@JsonProperty(value = "binName", required = true) String binName,
-                               @JsonProperty(value = "index", required = true) int index) {
+    public ListRemoveOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index) {
         super(binName);
         this.index = index;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveRangeOperation.java
@@ -31,9 +31,9 @@ public class ListRemoveRangeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_RANGE,
             required = true,
-            allowableValues = OperationTypes.LIST_REMOVE_RANGE
+            allowableValues = {OperationTypes.LIST_REMOVE_RANGE}
     )
-    final public static String type = OperationTypes.LIST_REMOVE_RANGE;
+    final public String type = OperationTypes.LIST_REMOVE_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -41,8 +41,11 @@ public class ListRemoveRangeOperation extends ListOperation {
     private Integer count;
 
     @JsonCreator
-    public ListRemoveRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                    @JsonProperty(value = "index", required = true) Integer index) {
+    public ListRemoveRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Integer index) {
         super(binName);
         this.index = index;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListRemoveRangeOperation.java
@@ -30,12 +30,12 @@ public class ListRemoveRangeOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_REMOVE_RANGE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_REMOVE_RANGE}
     )
     final public String type = OperationTypes.LIST_REMOVE_RANGE;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int index;
 
     private Integer count;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListSetOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListSetOperation.java
@@ -32,9 +32,9 @@ public class ListSetOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_SET,
             required = true,
-            allowableValues = OperationTypes.LIST_SET
+            allowableValues = {OperationTypes.LIST_SET}
     )
-    final public static String type = OperationTypes.LIST_SET;
+    final public String type = OperationTypes.LIST_SET;
 
     @Schema(required = true)
     private final int index;
@@ -45,9 +45,13 @@ public class ListSetOperation extends ListOperation {
     private ListPolicy listPolicy;
 
     @JsonCreator
-    public ListSetOperation(@JsonProperty(value = "binName", required = true) String binName,
-                            @JsonProperty(value = "index", required = true) int index,
-                            @JsonProperty(value = "value", required = true) Object value) {
+    public ListSetOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value) {
         super(binName);
         this.index = index;
         this.value = value;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListSetOrderOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListSetOrderOperation.java
@@ -32,16 +32,19 @@ public class ListSetOrderOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_SET_ORDER,
             required = true,
-            allowableValues = OperationTypes.LIST_SET_ORDER
+            allowableValues = {OperationTypes.LIST_SET_ORDER}
     )
-    final public static String type = OperationTypes.LIST_SET_ORDER;
+    final public String type = OperationTypes.LIST_SET_ORDER;
 
     @Schema(required = true)
     private final ListOrder listOrder;
 
     @JsonCreator
-    public ListSetOrderOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                 @JsonProperty(value = "listOrder", required = true) ListOrder listOrder) {
+    public ListSetOrderOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @Schema(
+            name = "listOrder", requiredMode = Schema.RequiredMode.REQUIRED
+    ) ListOrder listOrder) {
         super(binName);
         this.listOrder = listOrder;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListSizeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListSizeOperation.java
@@ -31,12 +31,14 @@ public class ListSizeOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_SIZE,
             required = true,
-            allowableValues = OperationTypes.LIST_SIZE
+            allowableValues = {OperationTypes.LIST_SIZE}
     )
-    final public static String type = OperationTypes.LIST_SIZE;
+    final public String type = OperationTypes.LIST_SIZE;
 
     @JsonCreator
-    public ListSizeOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public ListSizeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         super(binName);
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListSortOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListSortOperation.java
@@ -34,14 +34,16 @@ public class ListSortOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_SORT,
             required = true,
-            allowableValues = OperationTypes.LIST_SORT
+            allowableValues = {OperationTypes.LIST_SORT}
     )
-    final public static String type = OperationTypes.LIST_SORT;
+    final public String type = OperationTypes.LIST_SORT;
 
     private List<ListSortFlag> sortFlags;
 
     @JsonCreator
-    public ListSortOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public ListSortOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         super(binName);
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListTrimOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListTrimOperation.java
@@ -31,9 +31,9 @@ public class ListTrimOperation extends ListOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_TRIM,
             required = true,
-            allowableValues = OperationTypes.LIST_TRIM
+            allowableValues = {OperationTypes.LIST_TRIM}
     )
-    final public static String type = OperationTypes.LIST_TRIM;
+    final public String type = OperationTypes.LIST_TRIM;
 
     @Schema(required = true)
     private final int index;
@@ -42,9 +42,13 @@ public class ListTrimOperation extends ListOperation {
     private final int count;
 
     @JsonCreator
-    public ListTrimOperation(@JsonProperty(value = "binName", required = true) String binName,
-                             @JsonProperty(value = "index", required = true) int index,
-                             @JsonProperty(value = "count", required = true) int count) {
+    public ListTrimOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(value = "count") @Schema(
+            name = "count", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int count) {
         super(binName);
         this.index = index;
         this.count = count;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ListTrimOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ListTrimOperation.java
@@ -30,15 +30,15 @@ public class ListTrimOperation extends ListOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.LIST_TRIM,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.LIST_TRIM}
     )
     final public String type = OperationTypes.LIST_TRIM;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int index;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int count;
 
     @JsonCreator

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapClearOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapClearOperation.java
@@ -31,12 +31,14 @@ public class MapClearOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_CLEAR,
             required = true,
-            allowableValues = OperationTypes.MAP_CLEAR
+            allowableValues = {OperationTypes.MAP_CLEAR}
     )
-    final public static String type = OperationTypes.MAP_CLEAR;
+    final public String type = OperationTypes.MAP_CLEAR;
 
     @JsonCreator
-    public MapClearOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public MapClearOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         super(binName);
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapCreateOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapCreateOperation.java
@@ -32,16 +32,19 @@ public class MapCreateOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_CREATE,
             required = true,
-            allowableValues = OperationTypes.MAP_CREATE
+            allowableValues = {OperationTypes.MAP_CREATE}
     )
-    final public static String type = OperationTypes.MAP_CREATE;
+    final public String type = OperationTypes.MAP_CREATE;
 
     @Schema(required = true)
     private final MapOrder mapOrder;
 
     @JsonCreator
-    public MapCreateOperation(@JsonProperty(value = "binName", required = true) String binName,
-                              @JsonProperty(value = "mapOrder", required = true) MapOrder mapOrder) {
+    public MapCreateOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @Schema(
+            name = "mapOrder", requiredMode = Schema.RequiredMode.REQUIRED
+    ) MapOrder mapOrder) {
         super(binName);
         this.mapOrder = mapOrder;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByIndexOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByIndexOperation.java
@@ -31,9 +31,9 @@ public class MapGetByIndexOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_INDEX,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_INDEX
+            allowableValues = {OperationTypes.MAP_GET_BY_INDEX}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_INDEX;
+    final public String type = OperationTypes.MAP_GET_BY_INDEX;
 
     @Schema(required = true)
     private final int index;
@@ -44,9 +44,13 @@ public class MapGetByIndexOperation extends MapOperation {
     private boolean inverted;
 
     @JsonCreator
-    public MapGetByIndexOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                  @JsonProperty(value = "index", required = true) int index,
-                                  @JsonProperty(value = "mapReturnType", required = true) MapReturnType mapReturnType) {
+    public MapGetByIndexOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @Schema(
+            name = "mapReturnType", requiredMode = Schema.RequiredMode.REQUIRED
+    ) MapReturnType mapReturnType) {
         super(binName);
         this.index = index;
         this.mapReturnType = mapReturnType;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByIndexRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByIndexRangeOperation.java
@@ -31,9 +31,9 @@ public class MapGetByIndexRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_INDEX_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_INDEX_RANGE
+            allowableValues = {OperationTypes.MAP_GET_BY_INDEX_RANGE}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_INDEX_RANGE;
+    final public String type = OperationTypes.MAP_GET_BY_INDEX_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -46,8 +46,11 @@ public class MapGetByIndexRangeOperation extends MapOperation {
     private Integer count;
 
     @JsonCreator
-    public MapGetByIndexRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                       @JsonProperty(value = "index", required = true) int index, @JsonProperty(
+    public MapGetByIndexRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyListOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyListOperation.java
@@ -34,9 +34,9 @@ public class MapGetByKeyListOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_KEY_LIST,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_KEY_LIST
+            allowableValues = {OperationTypes.MAP_GET_BY_KEY_LIST}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_KEY_LIST;
+    final public String type = OperationTypes.MAP_GET_BY_KEY_LIST;
 
     @Schema(required = true)
     private final List<Object> keys;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyOperation.java
@@ -32,9 +32,9 @@ public class MapGetByKeyOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_KEY,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_KEY
+            allowableValues = {OperationTypes.MAP_GET_BY_KEY}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_KEY;
+    final public String type = OperationTypes.MAP_GET_BY_KEY;
 
     @Schema(required = true)
     private final Object key;
@@ -45,9 +45,13 @@ public class MapGetByKeyOperation extends MapOperation {
     private boolean inverted;
 
     @JsonCreator
-    public MapGetByKeyOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                @JsonProperty(value = "key", required = true) Object key,
-                                @JsonProperty(value = "mapReturnType", required = true) MapReturnType mapReturnType) {
+    public MapGetByKeyOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "key") @Schema(
+            name = "key", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object key, @Schema(
+            name = "mapReturnType", requiredMode = Schema.RequiredMode.REQUIRED
+    ) MapReturnType mapReturnType) {
         super(binName);
         this.key = key;
         this.mapReturnType = mapReturnType;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyRangeOperation.java
@@ -32,9 +32,9 @@ public class MapGetByKeyRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_KEY_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_KEY_RANGE
+            allowableValues = {OperationTypes.MAP_GET_BY_KEY_RANGE}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_KEY_RANGE;
+    final public String type = OperationTypes.MAP_GET_BY_KEY_RANGE;
 
     @Schema(required = true)
     private final MapReturnType mapReturnType;
@@ -45,7 +45,9 @@ public class MapGetByKeyRangeOperation extends MapOperation {
     private Object keyEnd;
 
     @JsonCreator
-    public MapGetByKeyRangeOperation(@JsonProperty(value = "binName", required = true) String binName, @JsonProperty(
+    public MapGetByKeyRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyRelativeIndexRange.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyRelativeIndexRange.java
@@ -31,18 +31,18 @@ public class MapGetByKeyRelativeIndexRange extends MapOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_KEY_RELATIVE_INDEX_RANGE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.MAP_GET_BY_KEY_RELATIVE_INDEX_RANGE}
     )
     final public String type = OperationTypes.MAP_GET_BY_KEY_RELATIVE_INDEX_RANGE;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int index;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final Object value;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final MapReturnType mapReturnType;
 
     private boolean inverted;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyRelativeIndexRange.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByKeyRelativeIndexRange.java
@@ -32,9 +32,9 @@ public class MapGetByKeyRelativeIndexRange extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_KEY_RELATIVE_INDEX_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_KEY_RELATIVE_INDEX_RANGE
+            allowableValues = {OperationTypes.MAP_GET_BY_KEY_RELATIVE_INDEX_RANGE}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_KEY_RELATIVE_INDEX_RANGE;
+    final public String type = OperationTypes.MAP_GET_BY_KEY_RELATIVE_INDEX_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -50,9 +50,13 @@ public class MapGetByKeyRelativeIndexRange extends MapOperation {
     private Integer count;
 
     @JsonCreator
-    public MapGetByKeyRelativeIndexRange(@JsonProperty(value = "binName", required = true) String binName,
-                                         @JsonProperty(value = "index", required = true) int index,
-                                         @JsonProperty(value = "value", required = true) Object value, @JsonProperty(
+    public MapGetByKeyRelativeIndexRange(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByRankOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByRankOperation.java
@@ -31,9 +31,9 @@ public class MapGetByRankOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_RANK,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_RANK
+            allowableValues = {OperationTypes.MAP_GET_BY_RANK}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_RANK;
+    final public String type = OperationTypes.MAP_GET_BY_RANK;
 
     @Schema(required = true)
     private final int rank;
@@ -44,9 +44,13 @@ public class MapGetByRankOperation extends MapOperation {
     private boolean inverted;
 
     @JsonCreator
-    public MapGetByRankOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                 @JsonProperty(value = "rank", required = true) int rank,
-                                 @JsonProperty(value = "mapReturnType", required = true) MapReturnType mapReturnType) {
+    public MapGetByRankOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank, @Schema(
+            name = "mapReturnType", requiredMode = Schema.RequiredMode.REQUIRED
+    ) MapReturnType mapReturnType) {
         super(binName);
         this.rank = rank;
         this.mapReturnType = mapReturnType;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByRankRangeOperation.java
@@ -31,9 +31,9 @@ public class MapGetByRankRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_RANK_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_RANK_RANGE
+            allowableValues = {OperationTypes.MAP_GET_BY_RANK_RANGE}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_RANK_RANGE;
+    final public String type = OperationTypes.MAP_GET_BY_RANK_RANGE;
 
     @Schema(required = true)
     private final MapReturnType mapReturnType;
@@ -46,9 +46,13 @@ public class MapGetByRankRangeOperation extends MapOperation {
     private boolean inverted;
 
     @JsonCreator
-    public MapGetByRankRangeOperation(@JsonProperty(value = "binName", required = true) String binName, @JsonProperty(
+    public MapGetByRankRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(
             value = "mapReturnType", required = true
-    ) MapReturnType mapReturnType, @JsonProperty(value = "rank", required = true) int rank) {
+    ) MapReturnType mapReturnType, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank) {
         super(binName);
         this.mapReturnType = mapReturnType;
         this.rank = rank;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByRankRangeOperation.java
@@ -30,15 +30,15 @@ public class MapGetByRankRangeOperation extends MapOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_RANK_RANGE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.MAP_GET_BY_RANK_RANGE}
     )
     final public String type = OperationTypes.MAP_GET_BY_RANK_RANGE;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final MapReturnType mapReturnType;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int rank;
 
     private Integer count;
@@ -49,7 +49,9 @@ public class MapGetByRankRangeOperation extends MapOperation {
     public MapGetByRankRangeOperation(@JsonProperty(value = "binName") @Schema(
             name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
     ) String binName, @JsonProperty(
-            value = "mapReturnType", required = true
+            value = "mapReturnType"
+    ) @Schema(
+            name = "mapReturnType", requiredMode = Schema.RequiredMode.REQUIRED
     ) MapReturnType mapReturnType, @JsonProperty(value = "rank") @Schema(
             name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
     ) int rank) {

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByValueListOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByValueListOperation.java
@@ -34,9 +34,9 @@ public class MapGetByValueListOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_VALUE_LIST,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_VALUE_LIST
+            allowableValues = {OperationTypes.MAP_GET_BY_VALUE_LIST}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_VALUE_LIST;
+    final public String type = OperationTypes.MAP_GET_BY_VALUE_LIST;
 
     @Schema(required = true)
     private final List<Object> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByValueOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByValueOperation.java
@@ -32,9 +32,9 @@ public class MapGetByValueOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_VALUE,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_VALUE
+            allowableValues = {OperationTypes.MAP_GET_BY_VALUE}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_VALUE;
+    final public String type = OperationTypes.MAP_GET_BY_VALUE;
 
     @Schema(required = true)
     private final Object value;
@@ -45,9 +45,13 @@ public class MapGetByValueOperation extends MapOperation {
     private boolean inverted;
 
     @JsonCreator
-    public MapGetByValueOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                  @JsonProperty(value = "value", required = true) Object value,
-                                  @JsonProperty(value = "mapReturnType", required = true) MapReturnType mapReturnType) {
+    public MapGetByValueOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value, @Schema(
+            name = "mapReturnType", requiredMode = Schema.RequiredMode.REQUIRED
+    ) MapReturnType mapReturnType) {
         super(binName);
         this.value = value;
         this.mapReturnType = mapReturnType;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByValueRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByValueRangeOperation.java
@@ -32,9 +32,9 @@ public class MapGetByValueRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_VALUE_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_VALUE_RANGE
+            allowableValues = {OperationTypes.MAP_GET_BY_VALUE_RANGE}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_VALUE_RANGE;
+    final public String type = OperationTypes.MAP_GET_BY_VALUE_RANGE;
 
     @Schema(required = true)
     private final MapReturnType mapReturnType;
@@ -46,7 +46,9 @@ public class MapGetByValueRangeOperation extends MapOperation {
     private Object valueEnd;
 
     @JsonCreator
-    public MapGetByValueRangeOperation(@JsonProperty(value = "binName", required = true) String binName, @JsonProperty(
+    public MapGetByValueRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByValueRelativeRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapGetByValueRelativeRankRangeOperation.java
@@ -32,9 +32,9 @@ public class MapGetByValueRelativeRankRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_GET_BY_VALUE_RELATIVE_RANK_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_GET_BY_VALUE_RELATIVE_RANK_RANGE
+            allowableValues = {OperationTypes.MAP_GET_BY_VALUE_RELATIVE_RANK_RANGE}
     )
-    final public static String type = OperationTypes.MAP_GET_BY_VALUE_RELATIVE_RANK_RANGE;
+    final public String type = OperationTypes.MAP_GET_BY_VALUE_RELATIVE_RANK_RANGE;
 
     @Schema(required = true)
     private final int rank;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapIncrementOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapIncrementOperation.java
@@ -32,9 +32,9 @@ public class MapIncrementOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_INCREMENT,
             required = true,
-            allowableValues = OperationTypes.MAP_INCREMENT
+            allowableValues = {OperationTypes.MAP_INCREMENT}
     )
-    final public static String type = OperationTypes.MAP_INCREMENT;
+    final public String type = OperationTypes.MAP_INCREMENT;
 
     @Schema(required = true)
     private final Number incr;
@@ -45,9 +45,13 @@ public class MapIncrementOperation extends MapOperation {
     private MapPolicy mapPolicy;
 
     @JsonCreator
-    public MapIncrementOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                 @JsonProperty(value = "incr", required = true) Number incr,
-                                 @JsonProperty(value = "key", required = true) Object key) {
+    public MapIncrementOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "incr") @Schema(
+            name = "incr", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Number incr, @JsonProperty(value = "key") @Schema(
+            name = "key", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object key) {
         super(binName);
         this.incr = incr;
         this.key = key;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapOperation.java
@@ -132,13 +132,15 @@ import java.util.Optional;
 )
 abstract public class MapOperation extends Operation {
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     protected String binName;
 
     protected List<CTX> ctx;
 
     @JsonCreator
-    protected MapOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    protected MapOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         this.binName = binName;
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapPutItemsOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapPutItemsOperation.java
@@ -35,9 +35,9 @@ public class MapPutItemsOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_PUT_ITEMS,
             required = true,
-            allowableValues = OperationTypes.MAP_PUT_ITEMS
+            allowableValues = {OperationTypes.MAP_PUT_ITEMS}
     )
-    final public static String type = OperationTypes.MAP_PUT_ITEMS;
+    final public String type = OperationTypes.MAP_PUT_ITEMS;
 
     @Schema(required = true)
     private final Map<Object, Object> map;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapPutOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapPutOperation.java
@@ -32,9 +32,9 @@ public class MapPutOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_PUT,
             required = true,
-            allowableValues = OperationTypes.MAP_PUT
+            allowableValues = {OperationTypes.MAP_PUT}
     )
-    final public static String type = OperationTypes.MAP_PUT;
+    final public String type = OperationTypes.MAP_PUT;
 
     @Schema(required = true)
     private final Object key;
@@ -45,9 +45,13 @@ public class MapPutOperation extends MapOperation {
     private MapPolicy mapPolicy;
 
     @JsonCreator
-    public MapPutOperation(@JsonProperty(value = "binName", required = true) String binName,
-                           @JsonProperty(value = "key", required = true) Object key,
-                           @JsonProperty(value = "value", required = true) Object value) {
+    public MapPutOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "key") @Schema(
+            name = "key", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object key, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value) {
         super(binName);
         this.key = key;
         this.value = value;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByIndexOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByIndexOperation.java
@@ -31,9 +31,9 @@ public class MapRemoveByIndexOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_INDEX,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_INDEX
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_INDEX}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_INDEX;
+    final public String type = OperationTypes.MAP_REMOVE_BY_INDEX;
 
     @Schema(required = true)
     private final int index;
@@ -44,8 +44,11 @@ public class MapRemoveByIndexOperation extends MapOperation {
     private boolean inverted;
 
     @JsonCreator
-    public MapRemoveByIndexOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                     @JsonProperty(value = "index", required = true) int index, @JsonProperty(
+    public MapRemoveByIndexOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByIndexRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByIndexRangeOperation.java
@@ -30,15 +30,15 @@ public class MapRemoveByIndexRangeOperation extends MapOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_INDEX_RANGE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.MAP_REMOVE_BY_INDEX_RANGE}
     )
     final public String type = OperationTypes.MAP_REMOVE_BY_INDEX_RANGE;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final int index;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final MapReturnType mapReturnType;
 
     private boolean inverted;
@@ -51,7 +51,9 @@ public class MapRemoveByIndexRangeOperation extends MapOperation {
     ) String binName, @JsonProperty(value = "index") @Schema(
             name = "index", requiredMode = Schema.RequiredMode.REQUIRED
     ) int index, @JsonProperty(
-            value = "mapReturnType", required = true
+            value = "mapReturnType"
+    ) @Schema(
+            name = "mapReturnType", requiredMode = Schema.RequiredMode.REQUIRED
     ) MapReturnType mapReturnType) {
         super(binName);
         this.index = index;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByIndexRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByIndexRangeOperation.java
@@ -31,9 +31,9 @@ public class MapRemoveByIndexRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_INDEX_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_INDEX_RANGE
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_INDEX_RANGE}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_INDEX_RANGE;
+    final public String type = OperationTypes.MAP_REMOVE_BY_INDEX_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -46,8 +46,11 @@ public class MapRemoveByIndexRangeOperation extends MapOperation {
     private Integer count;
 
     @JsonCreator
-    public MapRemoveByIndexRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                          @JsonProperty(value = "index", required = true) int index, @JsonProperty(
+    public MapRemoveByIndexRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByKeyOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByKeyOperation.java
@@ -32,9 +32,9 @@ public class MapRemoveByKeyOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_KEY,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_KEY
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_KEY}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_KEY;
+    final public String type = OperationTypes.MAP_REMOVE_BY_KEY;
 
     @Schema(required = true)
     private final Object key;
@@ -45,8 +45,11 @@ public class MapRemoveByKeyOperation extends MapOperation {
     private boolean inverted = false;
 
     @JsonCreator
-    public MapRemoveByKeyOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                   @JsonProperty(value = "key", required = true) Object key, @JsonProperty(
+    public MapRemoveByKeyOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "key") @Schema(
+            name = "key", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object key, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByKeyRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByKeyRangeOperation.java
@@ -32,9 +32,9 @@ public class MapRemoveByKeyRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_KEY_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_KEY_RANGE
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_KEY_RANGE}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_KEY_RANGE;
+    final public String type = OperationTypes.MAP_REMOVE_BY_KEY_RANGE;
 
     @Schema(required = true)
     private final MapReturnType mapReturnType;
@@ -46,7 +46,9 @@ public class MapRemoveByKeyRangeOperation extends MapOperation {
     private Object keyEnd;
 
     @JsonCreator
-    public MapRemoveByKeyRangeOperation(@JsonProperty(value = "binName", required = true) String binName, @JsonProperty(
+    public MapRemoveByKeyRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByKeyRelativeIndexRange.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByKeyRelativeIndexRange.java
@@ -32,9 +32,9 @@ public class MapRemoveByKeyRelativeIndexRange extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_KEY_RELATIVE_INDEX_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_KEY_RELATIVE_INDEX_RANGE
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_KEY_RELATIVE_INDEX_RANGE}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_KEY_RELATIVE_INDEX_RANGE;
+    final public String type = OperationTypes.MAP_REMOVE_BY_KEY_RELATIVE_INDEX_RANGE;
 
     @Schema(required = true)
     private final int index;
@@ -50,9 +50,13 @@ public class MapRemoveByKeyRelativeIndexRange extends MapOperation {
     private Integer count;
 
     @JsonCreator
-    public MapRemoveByKeyRelativeIndexRange(@JsonProperty(value = "binName", required = true) String binName,
-                                            @JsonProperty(value = "index", required = true) int index,
-                                            @JsonProperty(value = "value", required = true) Object value, @JsonProperty(
+    public MapRemoveByKeyRelativeIndexRange(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "index") @Schema(
+            name = "index", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int index, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByRankOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByRankOperation.java
@@ -31,9 +31,9 @@ public class MapRemoveByRankOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_RANK,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_RANK
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_RANK}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_RANK;
+    final public String type = OperationTypes.MAP_REMOVE_BY_RANK;
 
     @Schema(required = true)
     private final int rank;
@@ -44,8 +44,11 @@ public class MapRemoveByRankOperation extends MapOperation {
     private boolean inverted;
 
     @JsonCreator
-    public MapRemoveByRankOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                    @JsonProperty(value = "rank", required = true) int rank, @JsonProperty(
+    public MapRemoveByRankOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByRankRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByRankRangeOperation.java
@@ -31,9 +31,9 @@ public class MapRemoveByRankRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_RANK_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_RANK_RANGE
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_RANK_RANGE}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_RANK_RANGE;
+    final public String type = OperationTypes.MAP_REMOVE_BY_RANK_RANGE;
 
     @Schema(required = true)
     private final int rank;
@@ -46,8 +46,11 @@ public class MapRemoveByRankRangeOperation extends MapOperation {
     private Integer count;
 
     @JsonCreator
-    public MapRemoveByRankRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                         @JsonProperty(value = "rank", required = true) int rank, @JsonProperty(
+    public MapRemoveByRankRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByValueListOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByValueListOperation.java
@@ -34,9 +34,9 @@ public class MapRemoveByValueListOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_VALUE_LIST,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_VALUE_LIST
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_VALUE_LIST}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_VALUE_LIST;
+    final public String type = OperationTypes.MAP_REMOVE_BY_VALUE_LIST;
 
     @Schema(required = true)
     private final List<Object> values;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByValueOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByValueOperation.java
@@ -32,9 +32,9 @@ public class MapRemoveByValueOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_VALUE,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_VALUE
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_VALUE}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_VALUE;
+    final public String type = OperationTypes.MAP_REMOVE_BY_VALUE;
 
     @Schema(required = true)
     private final Object value;
@@ -45,8 +45,11 @@ public class MapRemoveByValueOperation extends MapOperation {
     private boolean inverted = false;
 
     @JsonCreator
-    public MapRemoveByValueOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                     @JsonProperty(value = "value", required = true) Object value, @JsonProperty(
+    public MapRemoveByValueOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value, @JsonProperty(
             value = "mapReturnType", required = true
     ) MapReturnType mapReturnType) {
         super(binName);

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByValueRangeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByValueRangeOperation.java
@@ -32,9 +32,9 @@ public class MapRemoveByValueRangeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_VALUE_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_VALUE_RANGE
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_VALUE_RANGE}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_VALUE_RANGE;
+    final public String type = OperationTypes.MAP_REMOVE_BY_VALUE_RANGE;
 
     @Schema(required = true)
     private final MapReturnType mapReturnType;
@@ -46,10 +46,11 @@ public class MapRemoveByValueRangeOperation extends MapOperation {
     private Object valueEnd;
 
     @JsonCreator
-    public MapRemoveByValueRangeOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                          @JsonProperty(
-                                                  value = "mapReturnType", required = true
-                                          ) MapReturnType mapReturnType) {
+    public MapRemoveByValueRangeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(
+            value = "mapReturnType", required = true
+    ) MapReturnType mapReturnType) {
         super(binName);
         this.mapReturnType = mapReturnType;
         inverted = false;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByValueRelativeRankRange.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapRemoveByValueRelativeRankRange.java
@@ -32,9 +32,9 @@ public class MapRemoveByValueRelativeRankRange extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE,
             required = true,
-            allowableValues = OperationTypes.MAP_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE
+            allowableValues = {OperationTypes.MAP_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE}
     )
-    final public static String type = OperationTypes.MAP_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE;
+    final public String type = OperationTypes.MAP_REMOVE_BY_VALUE_RELATIVE_RANK_RANGE;
 
     @Schema(required = true)
     private final int rank;
@@ -50,12 +50,15 @@ public class MapRemoveByValueRelativeRankRange extends MapOperation {
     private Integer count;
 
     @JsonCreator
-    public MapRemoveByValueRelativeRankRange(@JsonProperty(value = "binName", required = true) String binName,
-                                             @JsonProperty(value = "rank", required = true) int rank,
-                                             @JsonProperty(value = "value", required = true) Object value,
-                                             @JsonProperty(
-                                                     value = "mapReturnType", required = true
-                                             ) MapReturnType mapReturnType) {
+    public MapRemoveByValueRelativeRankRange(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "rank") @Schema(
+            name = "rank", requiredMode = Schema.RequiredMode.REQUIRED
+    ) int rank, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value, @JsonProperty(
+            value = "mapReturnType", required = true
+    ) MapReturnType mapReturnType) {
         super(binName);
         this.rank = rank;
         this.value = value;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapSetPolicyOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapSetPolicyOperation.java
@@ -31,16 +31,19 @@ public class MapSetPolicyOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_SET_POLICY,
             required = true,
-            allowableValues = OperationTypes.MAP_SET_POLICY
+            allowableValues = {OperationTypes.MAP_SET_POLICY}
     )
-    final public static String type = OperationTypes.MAP_SET_POLICY;
+    final public String type = OperationTypes.MAP_SET_POLICY;
 
     @Schema(required = true)
     private final MapPolicy mapPolicy;
 
     @JsonCreator
-    public MapSetPolicyOperation(@JsonProperty(value = "binName", required = true) String binName,
-                                 @JsonProperty(value = "mapPolicy", required = true) MapPolicy mapPolicy) {
+    public MapSetPolicyOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @Schema(
+            name = "mapPolicy", requiredMode = Schema.RequiredMode.REQUIRED
+    ) MapPolicy mapPolicy) {
         super(binName);
         this.mapPolicy = mapPolicy;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapSizeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapSizeOperation.java
@@ -31,12 +31,14 @@ public class MapSizeOperation extends MapOperation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_SIZE,
             required = true,
-            allowableValues = OperationTypes.MAP_SIZE
+            allowableValues = {OperationTypes.MAP_SIZE}
     )
-    final public static String type = OperationTypes.MAP_SIZE;
+    final public String type = OperationTypes.MAP_SIZE;
 
     @JsonCreator
-    public MapSizeOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public MapSizeOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         super(binName);
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/MapSizeOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/MapSizeOperation.java
@@ -30,7 +30,7 @@ public class MapSizeOperation extends MapOperation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.MAP_SIZE,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.MAP_SIZE}
     )
     final public String type = OperationTypes.MAP_SIZE;

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/Operation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/Operation.java
@@ -56,7 +56,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
         description = "The base type for describing all operations. Should not be used directly."
 )
 abstract public class Operation {
-        abstract public com.aerospike.client.Operation toOperation();
+    abstract public com.aerospike.client.Operation toOperation();
 }
 
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/PrependOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/PrependOperation.java
@@ -32,9 +32,9 @@ public class PrependOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.PREPEND,
             required = true,
-            allowableValues = OperationTypes.PREPEND
+            allowableValues = {OperationTypes.PREPEND}
     )
-    final public static String type = OperationTypes.PREPEND;
+    final public String type = OperationTypes.PREPEND;
 
     @Schema(required = true)
     private final String binName;
@@ -43,8 +43,11 @@ public class PrependOperation extends Operation {
     private final String value;
 
     @JsonCreator
-    public PrependOperation(@JsonProperty(value = "binName", required = true) String binName,
-                            @JsonProperty(value = "value", required = true) String value) {
+    public PrependOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String value) {
         this.binName = binName;
         this.value = value;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/PrependOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/PrependOperation.java
@@ -31,15 +31,15 @@ public class PrependOperation extends Operation {
 
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.PREPEND,
-            required = true,
+            requiredMode = Schema.RequiredMode.REQUIRED,
             allowableValues = {OperationTypes.PREPEND}
     )
     final public String type = OperationTypes.PREPEND;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final String binName;
 
-    @Schema(required = true)
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private final String value;
 
     @JsonCreator

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/PutOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/PutOperation.java
@@ -33,9 +33,9 @@ public class PutOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.PUT,
             required = true,
-            allowableValues = OperationTypes.PUT
+            allowableValues = {OperationTypes.PUT}
     )
-    final public static String type = OperationTypes.PUT;
+    final public String type = OperationTypes.PUT;
 
     @Schema(required = true)
     private final String binName;
@@ -44,8 +44,11 @@ public class PutOperation extends Operation {
     private final Object value;
 
     @JsonCreator
-    public PutOperation(@JsonProperty(value = "binName", required = true) String binName,
-                        @JsonProperty(value = "value", required = true) Object value) {
+    public PutOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName, @JsonProperty(value = "value") @Schema(
+            name = "value", requiredMode = Schema.RequiredMode.REQUIRED
+    ) Object value) {
         this.binName = binName;
         this.value = value;
     }

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/ReadOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/ReadOperation.java
@@ -30,14 +30,16 @@ public class ReadOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.READ,
             required = true,
-            allowableValues = OperationTypes.READ
+            allowableValues = {OperationTypes.READ}
     )
-    final public static String type = OperationTypes.READ;
+    final public String type = OperationTypes.READ;
 
     @Schema(required = true)
     private final String binName;
 
-    public ReadOperation(@JsonProperty(value = "binName", required = true) String binName) {
+    public ReadOperation(@JsonProperty(value = "binName") @Schema(
+            name = "binName", requiredMode = Schema.RequiredMode.REQUIRED
+    ) String binName) {
         this.binName = binName;
     }
 

--- a/src/main/java/com/aerospike/restclient/domain/operationmodels/TouchOperation.java
+++ b/src/main/java/com/aerospike/restclient/domain/operationmodels/TouchOperation.java
@@ -29,9 +29,9 @@ public class TouchOperation extends Operation {
     @Schema(
             description = "The type of operation. It is always " + OperationTypes.TOUCH,
             required = true,
-            allowableValues = OperationTypes.TOUCH
+            allowableValues = {OperationTypes.TOUCH}
     )
-    final public static String type = OperationTypes.TOUCH;
+    final public String type = OperationTypes.TOUCH;
 
     @Override
     public com.aerospike.client.Operation toOperation() {

--- a/src/main/java/com/aerospike/restclient/domain/querymodels/QueryContainsLongFilter.java
+++ b/src/main/java/com/aerospike/restclient/domain/querymodels/QueryContainsLongFilter.java
@@ -32,12 +32,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class QueryContainsLongFilter extends QueryFilter {
     @Schema(
             description = "The type of query filter this object represents. It is always " + AerospikeAPIConstants.QueryFilterTypes.CONTAINS_LONG,
-            required = true,
-            allowableValues = AerospikeAPIConstants.QueryFilterTypes.CONTAINS_LONG
+//            required = true,
+            allowableValues = {AerospikeAPIConstants.QueryFilterTypes.CONTAINS_LONG}
     )
-    final public static String type = AerospikeAPIConstants.QueryFilterTypes.CONTAINS_LONG;
-
-    @Schema(required = true)
+    public String type = AerospikeAPIConstants.QueryFilterTypes.CONTAINS_LONG;
+    
     @JsonProperty(required = true)
     public Long value;
 

--- a/src/main/java/com/aerospike/restclient/domain/querymodels/QueryContainsStringFilter.java
+++ b/src/main/java/com/aerospike/restclient/domain/querymodels/QueryContainsStringFilter.java
@@ -32,9 +32,9 @@ public class QueryContainsStringFilter extends QueryFilter {
     @Schema(
             description = "The type of query filter this object represents. It is always " + AerospikeAPIConstants.QueryFilterTypes.CONTAINS_STRING,
             required = true,
-            allowableValues = AerospikeAPIConstants.QueryFilterTypes.CONTAINS_STRING
+            allowableValues = {AerospikeAPIConstants.QueryFilterTypes.CONTAINS_STRING}
     )
-    final public static String type = AerospikeAPIConstants.QueryFilterTypes.CONTAINS_STRING;
+    final public String type = AerospikeAPIConstants.QueryFilterTypes.CONTAINS_STRING;
 
     @Schema(required = true)
     public String value;

--- a/src/main/java/com/aerospike/restclient/domain/querymodels/QueryEqualLongFilter.java
+++ b/src/main/java/com/aerospike/restclient/domain/querymodels/QueryEqualLongFilter.java
@@ -31,9 +31,9 @@ public class QueryEqualLongFilter extends QueryFilter {
     @Schema(
             description = "The type of query filter this object represents. It is always " + AerospikeAPIConstants.QueryFilterTypes.EQUAL_LONG,
             required = true,
-            allowableValues = AerospikeAPIConstants.QueryFilterTypes.EQUAL_LONG
+            allowableValues = {AerospikeAPIConstants.QueryFilterTypes.EQUAL_LONG}
     )
-    final public static String type = AerospikeAPIConstants.QueryFilterTypes.EQUAL_LONG;
+    final public String type = AerospikeAPIConstants.QueryFilterTypes.EQUAL_LONG;
 
     @Schema(required = true)
     public Long value;

--- a/src/main/java/com/aerospike/restclient/domain/querymodels/QueryEqualsStringFilter.java
+++ b/src/main/java/com/aerospike/restclient/domain/querymodels/QueryEqualsStringFilter.java
@@ -30,9 +30,9 @@ public class QueryEqualsStringFilter extends QueryFilter {
     @Schema(
             description = "The type of query filter this object represents. It is always " + AerospikeAPIConstants.QueryFilterTypes.EQUAL_STRING,
             required = true,
-            allowableValues = AerospikeAPIConstants.QueryFilterTypes.EQUAL_STRING
+            allowableValues = {AerospikeAPIConstants.QueryFilterTypes.EQUAL_STRING}
     )
-    final public static String type = AerospikeAPIConstants.QueryFilterTypes.EQUAL_STRING;
+    final public String type = AerospikeAPIConstants.QueryFilterTypes.EQUAL_STRING;
 
     @Schema(required = true)
     public String value;

--- a/src/main/java/com/aerospike/restclient/domain/querymodels/QueryGeoContainsPointFilter.java
+++ b/src/main/java/com/aerospike/restclient/domain/querymodels/QueryGeoContainsPointFilter.java
@@ -33,9 +33,9 @@ public class QueryGeoContainsPointFilter extends QueryFilter {
     @Schema(
             description = "The type of query filter this object represents. It is always " + AerospikeAPIConstants.QueryFilterTypes.GEOCONTAINS_POINT,
             required = true,
-            allowableValues = AerospikeAPIConstants.QueryFilterTypes.GEOCONTAINS_POINT
+            allowableValues = {AerospikeAPIConstants.QueryFilterTypes.GEOCONTAINS_POINT}
     )
-    final public static String type = AerospikeAPIConstants.QueryFilterTypes.GEOCONTAINS_POINT;
+    final public String type = AerospikeAPIConstants.QueryFilterTypes.GEOCONTAINS_POINT;
 
     @Schema(description = "Longitude and Latitude of a point", required = true)
     public LngLat point;

--- a/src/main/java/com/aerospike/restclient/domain/querymodels/QueryGeoWithinPolygonFilter.java
+++ b/src/main/java/com/aerospike/restclient/domain/querymodels/QueryGeoWithinPolygonFilter.java
@@ -37,7 +37,7 @@ public class QueryGeoWithinPolygonFilter extends QueryFilter {
             required = true,
             allowableValues = {AerospikeAPIConstants.QueryFilterTypes.GEOWITHIN_REGION}
     )
-    final public static String type = AerospikeAPIConstants.QueryFilterTypes.GEOWITHIN_REGION;
+    final public String type = AerospikeAPIConstants.QueryFilterTypes.GEOWITHIN_REGION;
 
     @Schema(description = "Array of longitude and latitude describing a region.", required = true)
     public List<LngLat> polygon;

--- a/src/main/java/com/aerospike/restclient/domain/querymodels/QueryGeoWithinRadiusFilter.java
+++ b/src/main/java/com/aerospike/restclient/domain/querymodels/QueryGeoWithinRadiusFilter.java
@@ -31,10 +31,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class QueryGeoWithinRadiusFilter extends QueryFilter {
     @Schema(
             description = "The type of query filter this object represents. It is always " + AerospikeAPIConstants.QueryFilterTypes.GEOWITHIN_RADIUS,
-            required = true,
-            allowableValues = AerospikeAPIConstants.QueryFilterTypes.GEOWITHIN_RADIUS
+            allowableValues = {AerospikeAPIConstants.QueryFilterTypes.GEOWITHIN_RADIUS}
     )
-    final public static String type = AerospikeAPIConstants.QueryFilterTypes.GEOWITHIN_RADIUS;
+    public String type = AerospikeAPIConstants.QueryFilterTypes.GEOWITHIN_RADIUS;
 
     @Schema(description = "Array of longitude, latitude, and radius describing a circle.", required = true)
     public LngLatRad circle;

--- a/src/main/java/com/aerospike/restclient/domain/querymodels/QueryRangeFilter.java
+++ b/src/main/java/com/aerospike/restclient/domain/querymodels/QueryRangeFilter.java
@@ -31,10 +31,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class QueryRangeFilter extends QueryFilter {
     @Schema(
             description = "The type of query filter this object represents. It is always " + AerospikeAPIConstants.QueryFilterTypes.RANGE,
-            required = true,
-            allowableValues = AerospikeAPIConstants.QueryFilterTypes.RANGE
+            allowableValues = {AerospikeAPIConstants.QueryFilterTypes.RANGE}
+
     )
-    final public static String type = AerospikeAPIConstants.QueryFilterTypes.RANGE;
+    public String type = AerospikeAPIConstants.QueryFilterTypes.RANGE;
+
     @Schema(description = "Filter begin value inclusive.", required = true)
     public long begin;
 

--- a/src/main/java/com/aerospike/restclient/util/AerospikeAPIConstants.java
+++ b/src/main/java/com/aerospike/restclient/util/AerospikeAPIConstants.java
@@ -122,6 +122,8 @@ public final class AerospikeAPIConstants {
         public static final String GEOCONTAINS_POINT = "GEO_CONTAINS_POINT";
     }
 
+    public static final String[] test = new String[]{QueryFilterTypes.RANGE};
+
     // INFO POLICY KEYS
     public static final String TIMEOUT = "timeout";
 

--- a/src/main/java/com/aerospike/restclient/util/annotations/ASRestClientOperateReadQueryParams.java
+++ b/src/main/java/com/aerospike/restclient/util/annotations/ASRestClientOperateReadQueryParams.java
@@ -54,7 +54,7 @@ import java.lang.annotation.Target;
         ), @Parameter(
                 name = AerospikeAPIConstants.RECORD_KEY,
                 description = APIDescriptors.RECORD_KEY_NOTES,
-                array = @ArraySchema(schema = @Schema(type = "string", required = true)),
+                array = @ArraySchema(schema = @Schema(type = "string", requiredMode = Schema.RequiredMode.REQUIRED)),
                 required = true,
                 in = ParameterIn.QUERY
         )

--- a/src/main/java/com/aerospike/restclient/util/annotations/ASRestDocumentPolicyQueryParams.java
+++ b/src/main/java/com/aerospike/restclient/util/annotations/ASRestDocumentPolicyQueryParams.java
@@ -35,13 +35,13 @@ import java.lang.annotation.Target;
                 @Parameter(
                         name = AerospikeAPIConstants.JSON_PATH,
                         description = APIDescriptors.JSON_PATH_NOTES,
-                        schema = @Schema(type = "string", required = true),
+                        schema = @Schema(type = "string", requiredMode = Schema.RequiredMode.REQUIRED),
                         required = true,
                         in = ParameterIn.QUERY
                 ), @Parameter(
                 name = AerospikeAPIConstants.RECORD_BINS,
                 description = APIDescriptors.JSON_PATH_BINS_NOTES,
-                array = @ArraySchema(schema = @Schema(type = "string", required = true)),
+                array = @ArraySchema(schema = @Schema(type = "string", requiredMode = Schema.RequiredMode.REQUIRED)),
                 required = true,
                 in = ParameterIn.QUERY
         ),

--- a/src/main/java/com/aerospike/restclient/util/annotations/ASRestDocumentWritePolicyQueryParams.java
+++ b/src/main/java/com/aerospike/restclient/util/annotations/ASRestDocumentWritePolicyQueryParams.java
@@ -38,13 +38,13 @@ import java.lang.annotation.Target;
                 @Parameter(
                         name = AerospikeAPIConstants.JSON_PATH,
                         description = APIDescriptors.JSON_PATH_NOTES,
-                        schema = @Schema(type = "string", required = true),
+                        schema = @Schema(type = "string", requiredMode = Schema.RequiredMode.REQUIRED),
                         required = true,
                         in = ParameterIn.QUERY
                 ), @Parameter(
                 name = AerospikeAPIConstants.RECORD_BINS,
                 description = APIDescriptors.JSON_PATH_BINS_NOTES,
-                array = @ArraySchema(schema = @Schema(type = "string", required = true)),
+                array = @ArraySchema(schema = @Schema(type = "string", requiredMode = Schema.RequiredMode.REQUIRED)),
                 required = true,
                 in = ParameterIn.QUERY
         ),


### PR DESCRIPTION
Things fixed:
- Deprecated `Schema.required` was replaced by `Schema.requiredMode`
- Models with `type` now correctly display their expected value in the Swagger docs by converting the `String` to a single element `String[]`. I can only assume this changed in a recent jump in the library we use to generate swagger docs
- Models that use a constructor with getters/setters to define required/optional fields respectively now correctly display required fields as required in the swagger docs. Again, I can only assume this broke due to a recent change in the lib used to generate the swagger docs.