### PR TITLE
APPS-941 Fix http2 rapid-reset vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
 plugins {
     id("application")
-    id('com.palantir.git-version') version "0.15.0"
+    id('com.palantir.git-version') version "3.0.0"
     id("org.springdoc.openapi-gradle-plugin") version "1.8.0"
 }
 
@@ -78,7 +78,7 @@ dependencies {
     implementation("com.aerospike:aerospike-document-api:1.2.0")
     implementation("org.msgpack:jackson-dataformat-msgpack:0.9.3")
     implementation('org.springframework.retry:spring-retry:2.0.1')
-    implementation('org.springframework:spring-aspects:6.0.9')
+    implementation('org.springframework:spring-aspects:6.0.13')
     implementation('org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j:3.0.3')
     implementation('org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0')
     implementation("javax.inject:javax.inject:1")

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,11 @@ buildscript {
     }
 }
 
+
 plugins {
-    id("org.springdoc.openapi-gradle-plugin") version "1.6.0"
-    id 'com.palantir.git-version' version "0.15.0"
+    id("application")
+    id('com.palantir.git-version') version "0.15.0"
+    id("org.springdoc.openapi-gradle-plugin") version "1.8.0"
 }
 
 if (findProperty("aerospikeUseLocal")) {
@@ -77,14 +79,14 @@ dependencies {
     implementation("org.msgpack:jackson-dataformat-msgpack:0.9.3")
     implementation('org.springframework.retry:spring-retry:2.0.1')
     implementation('org.springframework:spring-aspects:6.0.9')
-    implementation('org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j:3.0.0')
-    implementation('org.springdoc:springdoc-openapi-ui:1.6.15')
+    implementation('org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j:3.0.3')
+    implementation('org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0')
     implementation("javax.inject:javax.inject:1")
     implementation("com.google.guava:guava:31.1-jre")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.apache.httpcomponents:httpclient:${httpclientVersion}")
     implementation('org.springframework.boot:spring-boot-starter-actuator')
-    implementation('io.github.resilience4j:resilience4j-micrometer:1.7.1')
+    implementation('io.github.resilience4j:resilience4j-micrometer:2.0.2')
     implementation('io.micrometer:micrometer-registry-prometheus')
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,8 @@
 buildscript {
     ext {
-        springBootVersion = "2.7.11"
+        springBootVersion = "3.1.5"
         httpclientVersion = "4.5.14"
         aerospikeClientVersion = findProperty("aerospikeClientVersion") ?: "7.1.0"
-        set('snakeyaml.version', '2.0') // Can be removed after upgrading to springboot 3.x
     }
     if (findProperty("aerospikeUseLocal")) {
         print("using Local repo")
@@ -72,15 +71,14 @@ openApi {
 
 dependencies {
     implementation('org.msgpack:msgpack-core:0.9.3')
-    implementation('org.springframework.boot:spring-boot-starter-web:3.0.6')
-    // Separately upgraded to fix vulnerability. Version should be removed after upgrading to spring-boot 3.x
+    implementation("org.springframework.boot:spring-boot-starter-web:${springBootVersion}")
     implementation("com.aerospike:aerospike-client:${aerospikeClientVersion}")
     implementation("com.aerospike:aerospike-document-api:1.2.0")
     implementation("org.msgpack:jackson-dataformat-msgpack:0.9.3")
     implementation('org.springframework.retry:spring-retry:2.0.1')
-    implementation('org.springframework:spring-aspects:6.0.6')
+    implementation('org.springframework:spring-aspects:6.0.9')
     implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j:2.1.7")
-    implementation('org.springdoc:springdoc-openapi-ui:1.6.14')
+    implementation('org.springdoc:springdoc-openapi-ui:1.6.15')
     implementation("javax.inject:javax.inject:1")
     implementation("com.google.guava:guava:31.1-jre")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = "3.1.5"
+        springBootVersion = "3.0.12"
         httpclientVersion = "4.5.14"
         aerospikeClientVersion = findProperty("aerospikeClientVersion") ?: "7.1.0"
     }
@@ -77,7 +77,7 @@ dependencies {
     implementation("org.msgpack:jackson-dataformat-msgpack:0.9.3")
     implementation('org.springframework.retry:spring-retry:2.0.1')
     implementation('org.springframework:spring-aspects:6.0.9')
-    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j:2.1.7")
+    implementation('org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j:3.0.0')
     implementation('org.springdoc:springdoc-openapi-ui:1.6.15')
     implementation("javax.inject:javax.inject:1")
     implementation("com.google.guava:guava:31.1-jre")

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.apache.httpcomponents:httpclient:${httpclientVersion}")
     implementation('org.springframework.boot:spring-boot-starter-actuator')
-    implementation('io.github.resilience4j:resilience4j-micrometer:2.0.2')
+    implementation('io.github.resilience4j:resilience4j-micrometer:2.1.0')
     implementation('io.micrometer:micrometer-registry-prometheus')
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/java/com/aerospike/restclient/RestClientErrorHandler.java
+++ b/src/main/java/com/aerospike/restclient/RestClientErrorHandler.java
@@ -23,6 +23,7 @@ import com.aerospike.restclient.util.RestClientErrors;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -40,8 +41,9 @@ public class RestClientErrorHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(new RestClientError(ex), getStatusCodeFromException(ex));
     }
 
+    @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(
-            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status, WebRequest request
+            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request
     ) {
         logger.warn(ex.getMessage());
         return new ResponseEntity<>(new RestClientError(ex.getMostSpecificCause().getMessage()),

--- a/src/main/java/com/aerospike/restclient/RestClientErrorHandler.java
+++ b/src/main/java/com/aerospike/restclient/RestClientErrorHandler.java
@@ -40,13 +40,13 @@ public class RestClientErrorHandler extends ResponseEntityExceptionHandler {
         return new ResponseEntity<>(new RestClientError(ex), getStatusCodeFromException(ex));
     }
 
-    @Override
-    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
-                                                                  HttpHeaders headers, HttpStatus status,
-                                                                  WebRequest request) {
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatus status, WebRequest request
+    ) {
         logger.warn(ex.getMessage());
         return new ResponseEntity<>(new RestClientError(ex.getMostSpecificCause().getMessage()),
-                HttpStatus.BAD_REQUEST);
+                HttpStatus.BAD_REQUEST
+        );
     }
 
     @ExceptionHandler({RestClientErrors.AerospikeRestClientError.class})

--- a/src/main/java/com/aerospike/restclient/config/WebConfig.java
+++ b/src/main/java/com/aerospike/restclient/config/WebConfig.java
@@ -34,6 +34,7 @@
 package com.aerospike.restclient.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -53,12 +54,12 @@ public class WebConfig implements WebMvcConfigurer {
         converters.add(0, new MsgPackConverter());
         converters.add(0, new JSONMessageConverter());
         converters.add(0, new StringHttpMessageConverter());
+        converters.add(0, new ByteArrayHttpMessageConverter());
     }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**").allowedOrigins("*").allowedMethods("*").allowedHeaders("*");
-        //.allowCredentials(Boolean.TRUE);
     }
 }
 

--- a/src/main/java/com/aerospike/restclient/controllers/AdminController.java
+++ b/src/main/java/com/aerospike/restclient/controllers/AdminController.java
@@ -33,11 +33,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
 import java.util.List;
 
 @Tag(name = "Admin Operations", description = "Manage users and privileges.")
@@ -101,12 +101,12 @@ public class AdminController {
     )
     @DefaultRestClientAPIResponses
     @RequestMapping(
-            method = RequestMethod.GET,
-            value = "/user/{user}",
-            produces = {"application/json", "application/msgpack"}
+            method = RequestMethod.GET, value = "/user/{user}", produces = {"application/json", "application/msgpack"}
     )
-    public User getUser(@Parameter(required = true) @PathVariable(value = "user") String user,
-                        @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public User getUser(
+            @Parameter(required = true) @PathVariable(value = "user") String user,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         return adminService.getUser(authDetails, user);
@@ -131,8 +131,10 @@ public class AdminController {
     @DefaultRestClientAPIResponses
     @ResponseStatus(value = HttpStatus.ACCEPTED)
     @DeleteMapping(value = "/user/{user}", produces = {"application/json", "application/msgpack"})
-    public void dropUser(@Parameter(required = true) @PathVariable(value = "user") String user,
-                         @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void dropUser(
+            @Parameter(required = true) @PathVariable(value = "user") String user,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.dropUser(authDetails, user);
@@ -161,9 +163,11 @@ public class AdminController {
             consumes = {"application/json", "application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void changePassword(@Parameter(required = true) @PathVariable(value = "user") String user,
-                               @Parameter(required = true) @RequestBody String password,
-                               @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void changePassword(
+            @Parameter(required = true) @PathVariable(value = "user") String user,
+            @Parameter(required = true) @RequestBody String password,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.changePassword(authDetails, user, password);
@@ -196,8 +200,10 @@ public class AdminController {
             consumes = {"application/json", "application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void createUser(@Parameter(required = true) @Valid @RequestBody RestClientUserModel userInfo,
-                           @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void createUser(
+            @Parameter(required = true) @Valid @RequestBody RestClientUserModel userInfo,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.createUser(authDetails, userInfo);
@@ -231,17 +237,17 @@ public class AdminController {
             consumes = {"application/json", "application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void grantRoles(@Parameter(required = true) @PathVariable(value = "user") String user,
-                           @io.swagger.v3.oas.annotations.parameters.RequestBody(
-                                   required = true,
-                                   content = @Content(
-                                           examples = @ExampleObject(
-                                                   name = RequestBodyExamples.ROLES_NAME,
-                                                   value = RequestBodyExamples.ROLES_VALUE
-                                           )
-                                   )
-                           ) @RequestBody List<String> roles,
-                           @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void grantRoles(
+            @Parameter(required = true) @PathVariable(value = "user") String user,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true, content = @Content(
+                    examples = @ExampleObject(
+                            name = RequestBodyExamples.ROLES_NAME, value = RequestBodyExamples.ROLES_VALUE
+                    )
+            )
+            ) @RequestBody List<String> roles,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.grantRoles(authDetails, user, roles);
@@ -275,18 +281,17 @@ public class AdminController {
             consumes = {"application/json", "application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void revokeRoles(@PathVariable(value = "user") @Parameter(
-            description = "The user from which to revoke roles",
-            required = true
-    ) String user, @io.swagger.v3.oas.annotations.parameters.RequestBody(
-            required = true,
-            content = @Content(
-                    examples = @ExampleObject(
-                            name = RequestBodyExamples.ROLES_NAME,
-                            value = RequestBodyExamples.ROLES_VALUE
-                    )
+    public void revokeRoles(
+            @PathVariable(value = "user") @Parameter(
+                    description = "The user from which to revoke roles", required = true
+            ) String user, @io.swagger.v3.oas.annotations.parameters.RequestBody(
+            required = true, content = @Content(
+            examples = @ExampleObject(
+                    name = RequestBodyExamples.ROLES_NAME, value = RequestBodyExamples.ROLES_VALUE
             )
-    ) @RequestBody List<String> roles, @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    )
+    ) @RequestBody List<String> roles, @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.revokeRoles(authDetails, user, roles);
@@ -339,8 +344,10 @@ public class AdminController {
             consumes = {"application/json", "application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void createRole(@Parameter(required = true) @RequestBody RestClientRole rcRole,
-                           @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void createRole(
+            @Parameter(required = true) @RequestBody RestClientRole rcRole,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.createRole(authDetails, rcRole);
@@ -364,11 +371,12 @@ public class AdminController {
     )
     @DefaultRestClientAPIResponses
     @GetMapping(value = "/role/{name}", produces = {"application/json", "application/msgpack"})
-    public RestClientRole getRole(@Parameter(
-            description = "The name of the role whose information should be retrieved.",
-            required = true
-    ) @PathVariable(value = "name") String role,
-                                  @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public RestClientRole getRole(
+            @Parameter(
+                    description = "The name of the role whose information should be retrieved.", required = true
+            ) @PathVariable(value = "name") String role,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         return adminService.getRole(authDetails, role);
@@ -401,11 +409,13 @@ public class AdminController {
             consumes = {"application/json", "application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void setRoleQuotas(@Parameter(
-            description = "The name of the role to which quotas will be set.",
-            required = true
-    ) @PathVariable(value = "name") String name, @Parameter(required = true) @RequestBody RestClientRoleQuota roleQuota,
-                              @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void setRoleQuotas(
+            @Parameter(
+                    description = "The name of the role to which quotas will be set.", required = true
+            ) @PathVariable(value = "name") String name,
+            @Parameter(required = true) @RequestBody RestClientRoleQuota roleQuota,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.setRoleQuotas(authDetails, name, roleQuota);
@@ -430,11 +440,12 @@ public class AdminController {
     @DefaultRestClientAPIResponses
     @ResponseStatus(value = HttpStatus.ACCEPTED)
     @DeleteMapping(value = "/role/{name}", produces = {"application/json", "application/msgpack"})
-    public void dropRole(@Parameter(
-            description = "The name of the role to remove.",
-            required = true
-    ) @PathVariable(value = "name") String role,
-                         @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void dropRole(
+            @Parameter(
+                    description = "The name of the role to remove.", required = true
+            ) @PathVariable(value = "name") String role,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.dropRole(authDetails, role);
@@ -467,12 +478,13 @@ public class AdminController {
             consumes = {"application/json", "application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void grantPrivileges(@Parameter(
-            description = "The name of the role to which privileges will be granted.",
-            required = true
-    ) @PathVariable(value = "name") String name,
-                                @Parameter(required = true) @RequestBody List<RestClientPrivilege> privileges,
-                                @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void grantPrivileges(
+            @Parameter(
+                    description = "The name of the role to which privileges will be granted.", required = true
+            ) @PathVariable(value = "name") String name,
+            @Parameter(required = true) @RequestBody List<RestClientPrivilege> privileges,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.grantPrivileges(authDetails, name, privileges);
@@ -505,12 +517,13 @@ public class AdminController {
             consumes = {"application/json", "application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void revokePrivileges(@Parameter(
-            description = "The name of the role from which privileges will be removed.",
-            required = true
-    ) @PathVariable(value = "name") String name,
-                                 @Parameter(required = true) @RequestBody List<RestClientPrivilege> privileges,
-                                 @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void revokePrivileges(
+            @Parameter(
+                    description = "The name of the role from which privileges will be removed.", required = true
+            ) @PathVariable(value = "name") String name,
+            @Parameter(required = true) @RequestBody List<RestClientPrivilege> privileges,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         adminService.revokePrivileges(authDetails, name, privileges);

--- a/src/main/java/com/aerospike/restclient/controllers/KeyValueController.java
+++ b/src/main/java/com/aerospike/restclient/controllers/KeyValueController.java
@@ -42,12 +42,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
@@ -100,18 +100,19 @@ public class KeyValueController {
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientParams.ASRestClientRecordBinsQueryParam
     @ASRestClientPolicyQueryParams
-    public RestClientRecord getRecordNamespaceSetKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace,
-                                                     @Parameter(description = SET_NOTES, required = true) @PathVariable(
-                                                             value = "set"
-                                                     ) String set, @Parameter(
+    public RestClientRecord getRecordNamespaceSetKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace,
+            @Parameter(description = SET_NOTES, required = true) @PathVariable(
+                    value = "set"
+            ) String set, @Parameter(
             description = USERKEY_NOTES, required = true
     ) @PathVariable(value = "key") String key,
-                                                     @Parameter(hidden = true) @RequestParam MultiValueMap<String, String> requestParams,
-                                                     @RequestHeader(
-                                                             value = "Authorization", required = false
-                                                     ) String basicAuth) {
+            @Parameter(hidden = true) @RequestParam MultiValueMap<String, String> requestParams, @RequestHeader(
+            value = "Authorization", required = false
+    ) String basicAuth
+    ) {
 
         String[] bins = RequestParamHandler.getBinsFromMap(requestParams);
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
@@ -146,15 +147,16 @@ public class KeyValueController {
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientParams.ASRestClientRecordBinsQueryParam
     @ASRestClientPolicyQueryParams
-    public RestClientRecord getRecordNamespaceKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public RestClientRecord getRecordNamespaceKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = USERKEY_NOTES, required = true
     ) @PathVariable(value = "key") String key,
-                                                  @Parameter(hidden = true) @RequestParam MultiValueMap<String, String> requestParams,
-                                                  @RequestHeader(
-                                                          value = "Authorization", required = false
-                                                  ) String basicAuth) {
+            @Parameter(hidden = true) @RequestParam MultiValueMap<String, String> requestParams, @RequestHeader(
+            value = "Authorization", required = false
+    ) String basicAuth
+    ) {
 
         String[] bins = RequestParamHandler.getBinsFromMap(requestParams);
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
@@ -198,17 +200,18 @@ public class KeyValueController {
     @DeleteMapping(value = "/{namespace}/{set}/{key}", produces = {"application/json", "application/msgpack"})
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void deleteRecordNamespaceSetKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void deleteRecordNamespaceSetKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = SET_NOTES, required = true
     ) @PathVariable(value = "set") String set, @Parameter(
             description = USERKEY_NOTES, required = true
     ) @PathVariable(value = "key") String key,
-                                            @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                            @RequestHeader(
-                                                    value = "Authorization", required = false
-                                            ) String basicAuth) {
+            @Parameter(hidden = true) @RequestParam Map<String, String> requestParams, @RequestHeader(
+            value = "Authorization", required = false
+    ) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams);
@@ -246,13 +249,15 @@ public class KeyValueController {
     @DeleteMapping(value = "/{namespace}/{key}", produces = {"application/json", "application/msgpack"})
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void deleteRecordNamespaceKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void deleteRecordNamespaceKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = USERKEY_NOTES, required = true
     ) @PathVariable(value = "key") String key,
-                                         @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                         @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+            @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams);
@@ -297,9 +302,10 @@ public class KeyValueController {
     )
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void replaceRecordNamespaceSetKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void replaceRecordNamespaceSetKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = SET_NOTES, required = true
     ) @PathVariable(value = "set") String set, @Parameter(description = USERKEY_NOTES, required = true) @PathVariable(
             value = "key"
@@ -310,9 +316,10 @@ public class KeyValueController {
             )
     )
     ) @RequestBody Map<String, Object> bins, @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                             @RequestHeader(
-                                                     value = "Authorization", required = false
-                                             ) String basicAuth) {
+            @RequestHeader(
+                    value = "Authorization", required = false
+            ) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.REPLACE_ONLY);
@@ -352,13 +359,13 @@ public class KeyValueController {
     )
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void replaceRecordNamespaceSetKeyMP(@PathVariable(value = "namespace") String namespace,
-                                               @PathVariable(value = "set") String set,
-                                               @PathVariable(value = "key") String key, InputStream dataStream,
-                                               @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                               @RequestHeader(
-                                                       value = "Authorization", required = false
-                                               ) String basicAuth) {
+    public void replaceRecordNamespaceSetKeyMP(
+            @PathVariable(value = "namespace") String namespace, @PathVariable(value = "set") String set,
+            @PathVariable(value = "key") String key, InputStream dataStream,
+            @Parameter(hidden = true) @RequestParam Map<String, String> requestParams, @RequestHeader(
+            value = "Authorization", required = false
+    ) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.REPLACE_ONLY);
@@ -401,9 +408,10 @@ public class KeyValueController {
     )
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void replaceRecordNamespaceKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void replaceRecordNamespaceKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = USERKEY_NOTES, required = true
     ) @PathVariable(value = "key") String key, @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = STORE_BINS_NOTES, required = true, content = @Content(
@@ -412,7 +420,8 @@ public class KeyValueController {
             )
     )
     ) @RequestBody Map<String, Object> bins, @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                          @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.REPLACE_ONLY);
@@ -428,11 +437,12 @@ public class KeyValueController {
             consumes = "application/msgpack",
             produces = {"application/json", "application/msgpack"}
     )
-    public void replaceRecordNamespaceKeyMP(@PathVariable(value = "namespace") String namespace,
-                                            @PathVariable(value = "key") String key, InputStream dataStream,
-                                            @RequestParam Map<String, String> requestParams, @RequestHeader(
+    public void replaceRecordNamespaceKeyMP(
+            @PathVariable(value = "namespace") String namespace, @PathVariable(value = "key") String key,
+            InputStream dataStream, @RequestParam Map<String, String> requestParams, @RequestHeader(
             value = "Authorization", required = false
-    ) String basicAuth) {
+    ) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.REPLACE_ONLY);
@@ -480,9 +490,10 @@ public class KeyValueController {
     )
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void createRecordNamespaceSetKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void createRecordNamespaceSetKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = SET_NOTES, required = true
     ) @PathVariable(value = "set") String set, @Parameter(
             description = USERKEY_NOTES, required = true
@@ -493,9 +504,10 @@ public class KeyValueController {
             )
     )
     ) @RequestBody Map<String, Object> bins, @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                            @RequestHeader(
-                                                    value = "Authorization", required = false
-                                            ) String basicAuth) {
+            @RequestHeader(
+                    value = "Authorization", required = false
+            ) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.CREATE_ONLY);
@@ -511,12 +523,13 @@ public class KeyValueController {
             consumes = {"application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void createRecordNamespaceSetKeyMP(@PathVariable(value = "namespace") String namespace,
-                                              @PathVariable(value = "set") String set,
-                                              @PathVariable(value = "key") String key, InputStream dataStream,
-                                              @RequestParam Map<String, String> requestParams, @RequestHeader(
+    public void createRecordNamespaceSetKeyMP(
+            @PathVariable(value = "namespace") String namespace, @PathVariable(value = "set") String set,
+            @PathVariable(value = "key") String key, InputStream dataStream,
+            @RequestParam Map<String, String> requestParams, @RequestHeader(
             value = "Authorization", required = false
-    ) String basicAuth) {
+    ) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.CREATE_ONLY);
@@ -559,9 +572,10 @@ public class KeyValueController {
     )
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void createRecordNamespaceKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void createRecordNamespaceKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = USERKEY_NOTES, required = true
     ) @PathVariable(value = "key") String key, @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = STORE_BINS_NOTES, required = true, content = @Content(
@@ -570,7 +584,8 @@ public class KeyValueController {
             )
     )
     ) @RequestBody Map<String, Object> bins, @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                         @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.CREATE_ONLY);
@@ -586,10 +601,11 @@ public class KeyValueController {
             consumes = {"application/msgpack"},
             produces = {"application/json", "application/msgpack"}
     )
-    public void createRecordNamespaceKeyMP(@PathVariable(value = "namespace") String namespace,
-                                           @PathVariable(value = "key") String key, InputStream dataStream,
-                                           @RequestParam Map<String, String> requestParams,
-                                           @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void createRecordNamespaceKeyMP(
+            @PathVariable(value = "namespace") String namespace, @PathVariable(value = "key") String key,
+            InputStream dataStream, @RequestParam Map<String, String> requestParams,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.CREATE_ONLY);
@@ -637,9 +653,10 @@ public class KeyValueController {
     )
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void updateRecordNamespaceSetKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void updateRecordNamespaceSetKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = SET_NOTES, required = true
     ) @PathVariable(value = "set") String set, @Parameter(
             description = USERKEY_NOTES, required = true
@@ -650,9 +667,10 @@ public class KeyValueController {
             )
     )
     ) @RequestBody Map<String, Object> bins, @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                            @RequestHeader(
-                                                    value = "Authorization", required = false
-                                            ) String basicAuth) {
+            @RequestHeader(
+                    value = "Authorization", required = false
+            ) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.UPDATE_ONLY);
@@ -668,12 +686,13 @@ public class KeyValueController {
             consumes = "application/msgpack",
             produces = {"application/json", "application/msgpack"}
     )
-    public void updateRecordNamespaceSetKeyMP(@PathVariable(value = "namespace") String namespace,
-                                              @PathVariable(value = "set") String set,
-                                              @PathVariable(value = "key") String key, InputStream dataStream,
-                                              @RequestParam Map<String, String> requestParams, @RequestHeader(
+    public void updateRecordNamespaceSetKeyMP(
+            @PathVariable(value = "namespace") String namespace, @PathVariable(value = "set") String set,
+            @PathVariable(value = "key") String key, InputStream dataStream,
+            @RequestParam Map<String, String> requestParams, @RequestHeader(
             value = "Authorization", required = false
-    ) String basicAuth) {
+    ) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.UPDATE_ONLY);
@@ -716,9 +735,10 @@ public class KeyValueController {
     )
     @ASRestClientParams.ASRestClientKeyTypeQueryParam
     @ASRestClientWritePolicyQueryParams
-    public void updateRecordNamespaceKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void updateRecordNamespaceKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = USERKEY_NOTES, required = true
     ) @PathVariable(value = "key") String key, @io.swagger.v3.oas.annotations.parameters.RequestBody(
             description = STORE_BINS_NOTES, required = true, content = @Content(
@@ -727,7 +747,8 @@ public class KeyValueController {
             )
     )
     ) @RequestBody Map<String, Object> bins, @Parameter(hidden = true) @RequestParam Map<String, String> requestParams,
-                                         @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.UPDATE_ONLY);
@@ -743,10 +764,11 @@ public class KeyValueController {
             consumes = "application/msgpack",
             produces = {"application/json", "application/msgpack"}
     )
-    public void updateRecordNamespaceKeyMP(@PathVariable(value = "namespace") String namespace,
-                                           @PathVariable(value = "key") String key, InputStream dataStream,
-                                           @RequestParam Map<String, String> requestParams,
-                                           @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+    public void updateRecordNamespaceKeyMP(
+            @PathVariable(value = "namespace") String namespace, @PathVariable(value = "key") String key,
+            InputStream dataStream, @RequestParam Map<String, String> requestParams,
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         RecordKeyType keyType = RequestParamHandler.getKeyTypeFromMap(requestParams);
         WritePolicy policy = RequestParamHandler.getWritePolicy(requestParams, RecordExistsAction.UPDATE_ONLY);
@@ -779,9 +801,10 @@ public class KeyValueController {
             value = "/{namespace}/{set}/{key}",
             produces = {"application/json", "application/msgpack"}
     )
-    public void recordExistsNamespaceSetKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void recordExistsNamespaceSetKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = SET_NOTES, required = true
     ) @PathVariable(value = "set") String set, @Parameter(
             description = USERKEY_NOTES, required = true
@@ -789,7 +812,8 @@ public class KeyValueController {
             name = "keytype", description = APIDescriptors.KEYTYPE_NOTES
     ) @RequestParam(value = "keytype", required = false) RecordKeyType keyType, @RequestHeader(
             value = "Authorization", required = false
-    ) String basicAuth) {
+    ) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         if (!service.recordExists(authDetails, namespace, set, key, keyType)) {
@@ -826,14 +850,16 @@ public class KeyValueController {
             value = "/{namespace}/{key}",
             produces = {"application/json", "application/msgpack"}
     )
-    public void recordExistsNamespaceKey(@Parameter(
-            description = NAMESPACE_NOTES, required = true
-    ) @PathVariable(value = "namespace") String namespace, @Parameter(
+    public void recordExistsNamespaceKey(
+            @Parameter(
+                    description = NAMESPACE_NOTES, required = true
+            ) @PathVariable(value = "namespace") String namespace, @Parameter(
             description = USERKEY_NOTES, required = true
     ) @PathVariable(value = "key") String key, @Parameter(hidden = true) HttpServletResponse res, @Parameter(
             name = "keytype", description = APIDescriptors.KEYTYPE_NOTES
     ) @RequestParam(value = "keytype", required = false) RecordKeyType keyType,
-                                         @RequestHeader(value = "Authorization", required = false) String basicAuth) {
+            @RequestHeader(value = "Authorization", required = false) String basicAuth
+    ) {
 
         AuthDetails authDetails = HeaderHandler.extractAuthDetails(basicAuth);
         if (!service.recordExists(authDetails, namespace, null, key, keyType)) {

--- a/src/main/java/com/aerospike/restclient/domain/RestClientError.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientError.java
@@ -57,8 +57,7 @@ public class RestClientError {
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
     public RestClientError(
-            @JsonProperty("message") String message,
-            @JsonProperty("inDoubt") boolean inDoubt,
+            @JsonProperty("message") String message, @JsonProperty("inDoubt") boolean inDoubt,
             @JsonProperty("internalErrorCode") int internalErrorCode
     ) {
         this.message = message;

--- a/src/main/java/com/aerospike/restclient/domain/RestClientPrivilege.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientPrivilege.java
@@ -19,8 +19,7 @@ package com.aerospike.restclient.domain;
 import com.aerospike.client.admin.Privilege;
 import com.aerospike.client.admin.PrivilegeCode;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 public class RestClientPrivilege {
 

--- a/src/main/java/com/aerospike/restclient/domain/RestClientRole.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientRole.java
@@ -20,8 +20,8 @@ import com.aerospike.client.admin.Role;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
-import javax.validation.constraints.NotNull;
 import java.util.List;
 
 @JsonInclude(Include.NON_NULL)

--- a/src/main/java/com/aerospike/restclient/domain/RestClientUserModel.java
+++ b/src/main/java/com/aerospike/restclient/domain/RestClientUserModel.java
@@ -18,8 +18,7 @@ package com.aerospike.restclient.domain;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 @JsonInclude(Include.NON_NULL)
 public class RestClientUserModel {

--- a/src/main/java/com/aerospike/restclient/service/AerospikeOperateServiceV1.java
+++ b/src/main/java/com/aerospike/restclient/service/AerospikeOperateServiceV1.java
@@ -48,12 +48,14 @@ public class AerospikeOperateServiceV1 implements AerospikeOperateService {
     private AerospikeClientPool clientPool;
 
     @Autowired
-    private CircuitBreakerFactory circuitBreakerFactory;
+    private CircuitBreakerFactory<?, ?> circuitBreakerFactory;
 
     @Deprecated
     @Override
-    public RestClientRecord operateV1(AuthDetails authDetails, String namespace, String set, String key,
-                                      List<RestClientOperation> opsList, RecordKeyType keyType, WritePolicy policy) {
+    public RestClientRecord operateV1(
+            AuthDetails authDetails, String namespace, String set, String key, List<RestClientOperation> opsList,
+            RecordKeyType keyType, WritePolicy policy
+    ) {
         List<Map<String, Object>> opsMapsList = opsList.stream().map(RestClientOperation::toMap).toList();
         com.aerospike.client.Operation[] operations = OperationsConverter.mapListToOperationsArray(opsMapsList);
         return operate(authDetails, namespace, set, key, operations, keyType, policy);
@@ -61,16 +63,20 @@ public class AerospikeOperateServiceV1 implements AerospikeOperateService {
 
     @Deprecated
     @Override
-    public RestClientRecord[] operateV1(AuthDetails authDetails, String namespace, String set, String[] keys,
-                                        List<RestClientOperation> opsList, RecordKeyType keyType, BatchPolicy policy) {
+    public RestClientRecord[] operateV1(
+            AuthDetails authDetails, String namespace, String set, String[] keys, List<RestClientOperation> opsList,
+            RecordKeyType keyType, BatchPolicy policy
+    ) {
         List<Map<String, Object>> opsMapsList = opsList.stream().map(RestClientOperation::toMap).toList();
         com.aerospike.client.Operation[] operations = OperationsConverter.mapListToOperationsArray(opsMapsList);
         return operate(authDetails, namespace, set, keys, operations, keyType, policy);
     }
 
     @Override
-    public OperateResponseRecordBody operateV2(AuthDetails authDetails, String namespace, String set, String key,
-                                               List<Operation> opsList, RecordKeyType keyType, WritePolicy policy) {
+    public OperateResponseRecordBody operateV2(
+            AuthDetails authDetails, String namespace, String set, String key, List<Operation> opsList,
+            RecordKeyType keyType, WritePolicy policy
+    ) {
         com.aerospike.client.Operation[] operations = opsList.stream()
                 .map(Operation::toOperation)
                 .toArray(com.aerospike.client.Operation[]::new);
@@ -78,17 +84,20 @@ public class AerospikeOperateServiceV1 implements AerospikeOperateService {
     }
 
     @Override
-    public OperateResponseRecordsBody operateV2(AuthDetails authDetails, String namespace, String set, String[] keys,
-                                                List<Operation> opsList, RecordKeyType keyType, BatchPolicy policy) {
+    public OperateResponseRecordsBody operateV2(
+            AuthDetails authDetails, String namespace, String set, String[] keys, List<Operation> opsList,
+            RecordKeyType keyType, BatchPolicy policy
+    ) {
         com.aerospike.client.Operation[] operations = opsList.stream()
                 .map(Operation::toOperation)
                 .toArray(com.aerospike.client.Operation[]::new);
         return new OperateResponseRecordsBody(operate(authDetails, namespace, set, keys, operations, keyType, policy));
     }
 
-    public RestClientRecord operate(AuthDetails authDetails, String namespace, String set, String key,
-                                    com.aerospike.client.Operation[] opsList, RecordKeyType keyType,
-                                    WritePolicy policy) {
+    public RestClientRecord operate(
+            AuthDetails authDetails, String namespace, String set, String key, com.aerospike.client.Operation[] opsList,
+            RecordKeyType keyType, WritePolicy policy
+    ) {
         CircuitBreaker circuitBreaker = circuitBreakerFactory.create("rest-client");
 
         Key opKey = KeyBuilder.buildKey(namespace, set, key, keyType);
@@ -101,9 +110,10 @@ public class AerospikeOperateServiceV1 implements AerospikeOperateService {
         return new RestClientRecord(fetchedRecord);
     }
 
-    public RestClientRecord[] operate(AuthDetails authDetails, String namespace, String set, String[] keys,
-                                      com.aerospike.client.Operation[] opsList, RecordKeyType keyType,
-                                      BatchPolicy policy) {
+    public RestClientRecord[] operate(
+            AuthDetails authDetails, String namespace, String set, String[] keys,
+            com.aerospike.client.Operation[] opsList, RecordKeyType keyType, BatchPolicy policy
+    ) {
         CircuitBreaker circuitBreaker = circuitBreakerFactory.create("rest-client");
 
         Key[] opKeys = Arrays.stream(keys)

--- a/src/main/java/com/aerospike/restclient/service/AerospikeRecordServiceV1.java
+++ b/src/main/java/com/aerospike/restclient/service/AerospikeRecordServiceV1.java
@@ -43,11 +43,13 @@ public class AerospikeRecordServiceV1 implements AerospikeRecordService {
     private AerospikeClientPool clientPool;
 
     @Autowired
-    private CircuitBreakerFactory circuitBreakerFactory;
+    private CircuitBreakerFactory<?, ?> circuitBreakerFactory;
 
     @Override
-    public RestClientRecord fetchRecord(AuthDetails authDetails, String namespace, String set, String key,
-                                        String[] bins, RecordKeyType keyType, Policy policy) {
+    public RestClientRecord fetchRecord(
+            AuthDetails authDetails, String namespace, String set, String key, String[] bins, RecordKeyType keyType,
+            Policy policy
+    ) {
         Record fetchedRecord;
         Key asKey = KeyBuilder.buildKey(namespace, set, key, keyType);
         CircuitBreaker circuitBreaker = circuitBreakerFactory.create("rest-client");
@@ -69,8 +71,9 @@ public class AerospikeRecordServiceV1 implements AerospikeRecordService {
     }
 
     @Override
-    public void deleteRecord(AuthDetails authDetails, String namespace, String set, String key, RecordKeyType keyType,
-                             WritePolicy policy) {
+    public void deleteRecord(
+            AuthDetails authDetails, String namespace, String set, String key, RecordKeyType keyType, WritePolicy policy
+    ) {
         Key asKey = KeyBuilder.buildKey(namespace, set, key, keyType);
         CircuitBreaker circuitBreaker = circuitBreakerFactory.create("rest-client");
 
@@ -85,8 +88,10 @@ public class AerospikeRecordServiceV1 implements AerospikeRecordService {
     }
 
     @Override
-    public void storeRecord(AuthDetails authDetails, String namespace, String set, String key,
-                            Map<String, Object> binMap, RecordKeyType keyType, WritePolicy policy) {
+    public void storeRecord(
+            AuthDetails authDetails, String namespace, String set, String key, Map<String, Object> binMap,
+            RecordKeyType keyType, WritePolicy policy
+    ) {
         Key asKey = KeyBuilder.buildKey(namespace, set, key, keyType);
         Bin[] recordBins = BinConverter.binsFromMap(binMap);
         CircuitBreaker circuitBreaker = circuitBreakerFactory.create("rest-client");
@@ -98,8 +103,9 @@ public class AerospikeRecordServiceV1 implements AerospikeRecordService {
     }
 
     @Override
-    public boolean recordExists(AuthDetails authDetails, String namespace, String set, String key,
-                                RecordKeyType keyType) {
+    public boolean recordExists(
+            AuthDetails authDetails, String namespace, String set, String key, RecordKeyType keyType
+    ) {
         Key asKey = KeyBuilder.buildKey(namespace, set, key, keyType);
         CircuitBreaker circuitBreaker = circuitBreakerFactory.create("rest-client");
         return circuitBreaker.run(


### PR DESCRIPTION
Fixed the rapid-reset http2 vulnerability by upgrading from spring-boot 2.7 to 3.0.12. Other dependencies required upgrading for compatibility reasons and others were upgraded for convenience. Upgrading spring-boot caused a few breaking changes mostly around imports e.g. `javax` is now moved to `jakarta`